### PR TITLE
Feature/import

### DIFF
--- a/cmd/store/main.go
+++ b/cmd/store/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cushycush/store/internal/config"
 	"github.com/cushycush/store/internal/doctor"
 	"github.com/cushycush/store/internal/hooks"
+	"github.com/cushycush/store/internal/importer"
 	"github.com/cushycush/store/internal/linker"
 	"github.com/cushycush/store/internal/platform"
 	"github.com/cushycush/store/internal/render"
@@ -44,6 +45,20 @@ func main() {
 		Long:  "Creates a .store/config.yaml file in the current directory.",
 		RunE:  runInit,
 	}
+
+	var importScanDirs []string
+	var importDryRun bool
+
+	importCmd := &cobra.Command{
+		Use:   "import",
+		Short: "Import existing symlinks into config",
+		Long:  "Scans directories for symlinks pointing into the repo and imports them as store entries.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runImport(importScanDirs, importDryRun)
+		},
+	}
+	importCmd.Flags().StringArrayVar(&importScanDirs, "scan-dir", nil, "directories to scan for symlinks (default: ~, ~/.config, ~/.local/share, ~/.local/bin)")
+	importCmd.Flags().BoolVar(&importDryRun, "dry-run", false, "print discovered imports without writing config")
 
 	// --- add command ---
 	var addTarget string
@@ -389,7 +404,7 @@ shell's startup file to enable tab completion.
 		RunE:  runDoctor,
 	}
 
-	rootCmd.AddCommand(initCmd, addCmd, modifyCmd, removeCmd, removeAllCmd, statusCmd, diffCmd, versionCmd, targetCmd, secretCmd, completionCmd, doctorCmd)
+	rootCmd.AddCommand(initCmd, importCmd, addCmd, modifyCmd, removeCmd, removeAllCmd, statusCmd, diffCmd, versionCmd, targetCmd, secretCmd, completionCmd, doctorCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
@@ -655,6 +670,142 @@ func runInit(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("Initialized store config at %s\n", config.ConfigPath(cwd))
 	return nil
+}
+
+func runImport(scanDirs []string, dryRun bool) error {
+	root, err := config.FindRoot()
+	if err != nil {
+		return err
+	}
+
+	cfg, err := config.Load(root)
+	if err != nil {
+		return err
+	}
+
+	if len(scanDirs) == 0 {
+		scanDirs = defaultImportScanDirs()
+	}
+
+	fmt.Printf("Scanning for symlinks pointing into %s...\n\n", root)
+
+	links, err := importer.Scan(root, scanDirs)
+	if err != nil {
+		return err
+	}
+	links = filterImportLinks(links, cfg.Stores)
+	if len(links) == 0 {
+		fmt.Println("No new symlinks found")
+		return nil
+	}
+
+	printImportLinks(root, links)
+	entries := importer.ToConfig(links, root)
+
+	if dryRun {
+		fmt.Printf("\nDry run: would import %s as %s\n", pluralizeCount(len(links), "symlink", "symlinks"), pluralizeCount(len(entries), "store", "stores"))
+		return nil
+	}
+
+	if !forceBackups {
+		prompt := fmt.Sprintf("Import %s as %s?", pluralizeCount(len(links), "symlink", "symlinks"), pluralizeCount(len(entries), "store", "stores"))
+		if !promptYesNo(prompt) {
+			return fmt.Errorf("aborted")
+		}
+	}
+
+	for name, entry := range entries {
+		if _, exists := cfg.Stores[name]; exists {
+			continue
+		}
+		cfg.Stores[name] = entry
+	}
+
+	if err := config.Save(root, cfg); err != nil {
+		return err
+	}
+
+	configPath, err := filepath.Rel(root, config.ConfigPath(root))
+	if err != nil {
+		configPath = config.ConfigPath(root)
+	}
+
+	fmt.Printf("Imported %s to %s\n", pluralizeCount(len(entries), "store", "stores"), configPath)
+	return nil
+}
+
+func defaultImportScanDirs() []string {
+	return []string{"~", "~/.config", "~/.local/share", "~/.local/bin"}
+}
+
+func filterImportLinks(links []importer.DiscoveredLink, existing map[string]config.StoreEntry) []importer.DiscoveredLink {
+	filtered := make([]importer.DiscoveredLink, 0, len(links))
+	for _, link := range links {
+		if _, exists := existing[link.StoreName]; exists {
+			continue
+		}
+		filtered = append(filtered, link)
+	}
+	return filtered
+}
+
+func printImportLinks(root string, links []importer.DiscoveredLink) {
+	fmt.Println("Found:")
+
+	nameWidth := len("store")
+	mappingWidth := 0
+	for _, link := range links {
+		if len(link.StoreName) > nameWidth {
+			nameWidth = len(link.StoreName)
+		}
+		mapping := fmt.Sprintf("%s -> %s", makePortablePath(link.Target), importSourceDisplay(root, link))
+		if len(mapping) > mappingWidth {
+			mappingWidth = len(mapping)
+		}
+	}
+
+	for _, link := range links {
+		kind := "file"
+		if link.File == "" {
+			kind = "whole directory"
+		}
+
+		mapping := fmt.Sprintf("%s -> %s", makePortablePath(link.Target), importSourceDisplay(root, link))
+		fmt.Printf("  %-*s %-*s (%s)\n", nameWidth, link.StoreName, mappingWidth, mapping, kind)
+	}
+}
+
+func makePortablePath(path string) string {
+	cleaned := filepath.Clean(path)
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return cleaned
+	}
+
+	home = filepath.Clean(home)
+	if cleaned == home {
+		return "~"
+	}
+
+	prefix := home + string(os.PathSeparator)
+	if suffix, ok := strings.CutPrefix(cleaned, prefix); ok {
+		return filepath.Join("~", suffix)
+	}
+
+	return cleaned
+}
+
+func importSourceDisplay(root string, link importer.DiscoveredLink) string {
+	rel, err := filepath.Rel(root, link.Source)
+	if err != nil {
+		rel = link.Source
+	}
+
+	rel = filepath.ToSlash(filepath.Clean(rel))
+	if link.File == "" && !strings.HasSuffix(rel, "/") {
+		return rel + "/"
+	}
+	return rel
 }
 
 func runAdd(name, target string, files, patterns []string) error {

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -1,0 +1,246 @@
+package importer
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/cushycush/store/internal/config"
+)
+
+// DiscoveredLink describes an existing symlink that points into the repo.
+type DiscoveredLink struct {
+	StoreName string // directory name in repo (e.g., "nvim")
+	Source    string // path in repo (e.g., "/home/user/dotfiles/nvim")
+	Target    string // symlink location (e.g., "/home/user/.config/nvim")
+	File      string // empty for whole-dir, relative path for file-mode (e.g., ".zshrc")
+}
+
+// Scan checks the given directories for symlinks pointing into repoRoot.
+func Scan(repoRoot string, scanDirs []string) ([]DiscoveredLink, error) {
+	absRepoRoot, err := filepath.Abs(repoRoot)
+	if err != nil {
+		return nil, fmt.Errorf("resolve repo root: %w", err)
+	}
+	realRepoRoot, err := filepath.EvalSymlinks(absRepoRoot)
+	if err == nil {
+		absRepoRoot = realRepoRoot
+	}
+	absRepoRoot = filepath.Clean(absRepoRoot)
+
+	storeDirs, err := topLevelStoreDirs(absRepoRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	var links []DiscoveredLink
+	for _, scanDir := range scanDirs {
+		expanded, err := config.ExpandHome(scanDir)
+		if err != nil {
+			return nil, fmt.Errorf("expand scan dir %q: %w", scanDir, err)
+		}
+		expanded, err = filepath.Abs(expanded)
+		if err != nil {
+			return nil, fmt.Errorf("resolve scan dir %q: %w", scanDir, err)
+		}
+
+		entries, err := os.ReadDir(expanded)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("read scan dir %q: %w", expanded, err)
+		}
+
+		for _, entry := range entries {
+			if entry.Type()&os.ModeSymlink == 0 {
+				continue
+			}
+
+			linkPath := filepath.Join(expanded, entry.Name())
+			targetPath, err := os.Readlink(linkPath)
+			if err != nil {
+				return nil, fmt.Errorf("read symlink %q: %w", linkPath, err)
+			}
+
+			if !filepath.IsAbs(targetPath) {
+				targetPath = filepath.Join(filepath.Dir(linkPath), targetPath)
+			}
+			targetPath, err = filepath.Abs(targetPath)
+			if err != nil {
+				return nil, fmt.Errorf("resolve symlink target %q: %w", linkPath, err)
+			}
+			if realTarget, err := filepath.EvalSymlinks(targetPath); err == nil {
+				targetPath = realTarget
+			}
+			targetPath = filepath.Clean(targetPath)
+
+			rel, ok := pathWithinRepo(absRepoRoot, targetPath)
+			if !ok || rel == "." {
+				continue
+			}
+
+			parts := strings.Split(rel, string(os.PathSeparator))
+			storeName := parts[0]
+			if !storeDirs[storeName] {
+				continue
+			}
+
+			file := ""
+			if len(parts) > 1 {
+				file = filepath.Clean(filepath.Join(parts[1:]...))
+			}
+
+			links = append(links, DiscoveredLink{
+				StoreName: storeName,
+				Source:    targetPath,
+				Target:    linkPath,
+				File:      file,
+			})
+		}
+	}
+
+	sort.Slice(links, func(i, j int) bool {
+		if links[i].StoreName != links[j].StoreName {
+			return links[i].StoreName < links[j].StoreName
+		}
+		if links[i].Target != links[j].Target {
+			return links[i].Target < links[j].Target
+		}
+		return links[i].File < links[j].File
+	})
+
+	return links, nil
+}
+
+// ToConfig converts discovered links into store config entries.
+func ToConfig(links []DiscoveredLink, _ string) map[string]config.StoreEntry {
+
+	type targetGroup struct {
+		wholeDir bool
+		files    map[string]struct{}
+	}
+
+	storeGroups := make(map[string]map[string]*targetGroup)
+	for _, link := range links {
+		target := portablePath(link.Target)
+		if link.File != "" {
+			target = portablePath(filepath.Dir(link.Target))
+		}
+
+		if storeGroups[link.StoreName] == nil {
+			storeGroups[link.StoreName] = make(map[string]*targetGroup)
+		}
+		if storeGroups[link.StoreName][target] == nil {
+			storeGroups[link.StoreName][target] = &targetGroup{files: make(map[string]struct{})}
+		}
+
+		group := storeGroups[link.StoreName][target]
+		if link.File == "" {
+			group.wholeDir = true
+			continue
+		}
+
+		group.files[filepath.Clean(link.File)] = struct{}{}
+	}
+
+	entries := make(map[string]config.StoreEntry)
+	storeNames := make([]string, 0, len(storeGroups))
+	for name := range storeGroups {
+		storeNames = append(storeNames, name)
+	}
+	sort.Strings(storeNames)
+
+	for _, storeName := range storeNames {
+		targetsByPath := storeGroups[storeName]
+		targetPaths := make([]string, 0, len(targetsByPath))
+		for target := range targetsByPath {
+			targetPaths = append(targetPaths, target)
+		}
+		sort.Strings(targetPaths)
+
+		targets := make([]config.TargetEntry, 0, len(targetPaths))
+		for _, target := range targetPaths {
+			group := targetsByPath[target]
+			entry := config.TargetEntry{Target: target}
+			if !group.wholeDir {
+				entry.Files = sortedKeys(group.files)
+			}
+			targets = append(targets, entry)
+		}
+
+		if len(targets) == 1 {
+			target := targets[0]
+			entries[storeName] = config.StoreEntry{
+				Target: target.Target,
+				Files:  target.Files,
+			}
+			continue
+		}
+
+		entries[storeName] = config.StoreEntry{Targets: targets}
+	}
+
+	return entries
+}
+
+func topLevelStoreDirs(repoRoot string) (map[string]bool, error) {
+	entries, err := os.ReadDir(repoRoot)
+	if err != nil {
+		return nil, fmt.Errorf("read repo root %q: %w", repoRoot, err)
+	}
+
+	storeDirs := make(map[string]bool)
+	for _, entry := range entries {
+		name := entry.Name()
+		if !entry.IsDir() || name == config.ConfigDir || strings.HasPrefix(name, ".") {
+			continue
+		}
+		storeDirs[name] = true
+	}
+
+	return storeDirs, nil
+}
+
+func pathWithinRepo(repoRoot, path string) (string, bool) {
+	rel, err := filepath.Rel(repoRoot, path)
+	if err != nil {
+		return "", false
+	}
+	rel = filepath.Clean(rel)
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", false
+	}
+	return rel, true
+}
+
+func portablePath(path string) string {
+	cleaned := filepath.Clean(path)
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return cleaned
+	}
+
+	home = filepath.Clean(home)
+	if cleaned == home {
+		return "~"
+	}
+
+	prefix := home + string(os.PathSeparator)
+	if suffix, ok := strings.CutPrefix(cleaned, prefix); ok {
+		return filepath.Join("~", suffix)
+	}
+
+	return cleaned
+}
+
+func sortedKeys(m map[string]struct{}) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -1,0 +1,216 @@
+package importer
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/cushycush/store/internal/config"
+)
+
+func TestScanWholeDirectorySymlink(t *testing.T) {
+	repoRoot := t.TempDir()
+	storeDir := filepath.Join(repoRoot, "nvim")
+	if err := os.MkdirAll(storeDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(storeDir): %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(repoRoot, config.ConfigDir), 0o755); err != nil {
+		t.Fatalf("MkdirAll(config dir): %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(repoRoot, ".hidden"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(hidden dir): %v", err)
+	}
+
+	scanDir := t.TempDir()
+	linkPath := filepath.Join(scanDir, "nvim")
+	if err := os.Symlink(storeDir, linkPath); err != nil {
+		t.Fatalf("Symlink(): %v", err)
+	}
+	if err := os.Symlink(filepath.Join(repoRoot, config.ConfigDir), filepath.Join(scanDir, ".store-link")); err != nil {
+		t.Fatalf("Symlink(config dir): %v", err)
+	}
+	if err := os.Symlink(filepath.Join(repoRoot, ".hidden"), filepath.Join(scanDir, "hidden-link")); err != nil {
+		t.Fatalf("Symlink(hidden dir): %v", err)
+	}
+
+	got, err := Scan(repoRoot, []string{scanDir})
+	if err != nil {
+		t.Fatalf("Scan() error = %v", err)
+	}
+
+	want := []DiscoveredLink{{
+		StoreName: "nvim",
+		Source:    storeDir,
+		Target:    linkPath,
+		File:      "",
+	}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Scan() = %#v, want %#v", got, want)
+	}
+}
+
+func TestScanFileModeSymlinks(t *testing.T) {
+	repoRoot := t.TempDir()
+	storeDir := filepath.Join(repoRoot, "shells")
+	if err := os.MkdirAll(storeDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(storeDir): %v", err)
+	}
+	zshrc := filepath.Join(storeDir, ".zshrc")
+	bashrc := filepath.Join(storeDir, ".bashrc")
+	for _, path := range []string{zshrc, bashrc} {
+		if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+			t.Fatalf("WriteFile(%q): %v", path, err)
+		}
+	}
+
+	scanDir := t.TempDir()
+	links := map[string]string{
+		filepath.Join(scanDir, ".zshrc"):  zshrc,
+		filepath.Join(scanDir, ".bashrc"): bashrc,
+	}
+	for link, target := range links {
+		if err := os.Symlink(target, link); err != nil {
+			t.Fatalf("Symlink(%q, %q): %v", target, link, err)
+		}
+	}
+
+	got, err := Scan(repoRoot, []string{scanDir})
+	if err != nil {
+		t.Fatalf("Scan() error = %v", err)
+	}
+
+	want := []DiscoveredLink{
+		{StoreName: "shells", Source: bashrc, Target: filepath.Join(scanDir, ".bashrc"), File: ".bashrc"},
+		{StoreName: "shells", Source: zshrc, Target: filepath.Join(scanDir, ".zshrc"), File: ".zshrc"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Scan() = %#v, want %#v", got, want)
+	}
+}
+
+func TestScanSkipsNonRepoSymlinksAndRegularFiles(t *testing.T) {
+	repoRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repoRoot, "git"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(repo store): %v", err)
+	}
+
+	scanDir := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "elsewhere")
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatalf("MkdirAll(outside): %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(scanDir, "elsewhere")); err != nil {
+		t.Fatalf("Symlink(outside): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(scanDir, "regular.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("WriteFile(regular): %v", err)
+	}
+
+	got, err := Scan(repoRoot, []string{scanDir})
+	if err != nil {
+		t.Fatalf("Scan() error = %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("Scan() = %#v, want no links", got)
+	}
+}
+
+func TestToConfigGroupingAndMixedMode(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	repoRoot := t.TempDir()
+
+	links := []DiscoveredLink{
+		{
+			StoreName: "shells",
+			Source:    filepath.Join(repoRoot, "shells", ".zshrc"),
+			Target:    filepath.Join(home, ".zshrc"),
+			File:      ".zshrc",
+		},
+		{
+			StoreName: "shells",
+			Source:    filepath.Join(repoRoot, "shells", ".bashrc"),
+			Target:    filepath.Join(home, ".bashrc"),
+			File:      ".bashrc",
+		},
+		{
+			StoreName: "git",
+			Source:    filepath.Join(repoRoot, "git"),
+			Target:    filepath.Join(home, ".config", "git"),
+			File:      "",
+		},
+		{
+			StoreName: "mixed",
+			Source:    filepath.Join(repoRoot, "mixed"),
+			Target:    filepath.Join(home, ".config", "mixed"),
+			File:      "",
+		},
+		{
+			StoreName: "mixed",
+			Source:    filepath.Join(repoRoot, "mixed", "extra.conf"),
+			Target:    filepath.Join(home, ".config", "mixed", "extra.conf"),
+			File:      "extra.conf",
+		},
+	}
+
+	got := ToConfig(links, repoRoot)
+	want := map[string]config.StoreEntry{
+		"shells": {
+			Target: "~",
+			Files:  []string{".bashrc", ".zshrc"},
+		},
+		"git": {
+			Target: "~/.config/git",
+		},
+		"mixed": {
+			Target: "~/.config/mixed",
+		},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ToConfig() = %#v, want %#v", got, want)
+	}
+}
+
+func TestToConfigMultiTargetAndHomePortability(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	repoRoot := t.TempDir()
+
+	links := []DiscoveredLink{
+		{
+			StoreName: "shells",
+			Source:    filepath.Join(repoRoot, "shells", ".zshrc"),
+			Target:    filepath.Join(home, ".zshrc"),
+			File:      ".zshrc",
+		},
+		{
+			StoreName: "shells",
+			Source:    filepath.Join(repoRoot, "shells", "config.fish"),
+			Target:    filepath.Join(home, ".config", "fish", "config.fish"),
+			File:      "config.fish",
+		},
+		{
+			StoreName: "shells",
+			Source:    filepath.Join(repoRoot, "shells", "config.nu"),
+			Target:    filepath.Join(home, ".config", "nushell", "config.nu"),
+			File:      "config.nu",
+		},
+	}
+
+	got := ToConfig(links, repoRoot)
+	want := map[string]config.StoreEntry{
+		"shells": {
+			Targets: []config.TargetEntry{
+				{Target: "~", Files: []string{".zshrc"}},
+				{Target: "~/.config/fish", Files: []string{"config.fish"}},
+				{Target: "~/.config/nushell", Files: []string{"config.nu"}},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ToConfig() = %#v, want %#v", got, want)
+	}
+}


### PR DESCRIPTION
## Import Existing Symlinks

Adds a `store import` command that scans directories for symlinks pointing into the repo and generates config entries from them. Useful for migrating from manual symlinks or from other dotfile managers.

### Usage

```sh
$ store import
Scanning for symlinks pointing into /home/user/dotfiles...

Found:
  nvim      ~/.config/nvim -> nvim/           (whole directory)
  shells    ~/.zshrc -> shells/.zshrc         (file)
  shells    ~/.bashrc -> shells/.bashrc       (file)
  git       ~/.config/git -> git/             (whole directory)

Import 4 symlinks as 3 stores? [y/N] y
Imported 3 stores to .store/config.yaml
```

### How it works

1. Scans each scan directory one level deep for symlinks
2. Checks if each symlink target resolves to a path inside the repo root
3. Groups discovered links by store name (top-level directory in the repo)
4. Determines mode: whole-directory if the symlink points to the store root, file-mode if it points to individual files
5. Handles multi-target grouping when files from the same store are symlinked to different directories
6. Skips stores that already exist in config
7. Prompts for confirmation before writing (unless `--force`)

### Flags

| Flag | Description |
|---|---|
| `--scan-dir` | Directories to scan for symlinks (repeatable). Defaults to `~`, `~/.config`, `~/.local/share`, `~/.local/bin` |
| `--dry-run` | Show what would be imported without writing config |

### Details

- Target paths under `$HOME` are stored with `~` prefix for portability across machines
- Only top-level repo directories are considered as stores (hidden dirs and `.store` are skipped)
- Existing config entries are never overwritten — only new stores are added

### Changes

- Added `internal/importer/` package with `Scan` and `ToConfig` functions
- Added `store import` command with `--scan-dir` and `--dry-run` flags
- 6 test cases covering whole-dir, file-mode, mixed, non-repo skip, multi-target grouping, and home path portability