### PR TITLE
Windows support: shell detection, hook dispatch, doctor probe, CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: Test ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        run: go test ./...
+
+      - name: Build
+        run: go build ./cmd/store

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= v1.1.1
+VERSION ?= v1.2.0
 
 build:
 	go build -ldflags "-X main.version=$(VERSION)" -o store ./cmd/store

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ $ go install github.com/cush/store/cmd/store@latest
 ```sh
 $ git clone https://github.com/cush/store.git
 $ cd store
-$ make build VERSION=1.1.1
+$ make build VERSION=1.2.0
 $ mv store /usr/local/bin/
 ```
 
@@ -462,7 +462,7 @@ $ store --version
 ```
 
 ```text
-store version 1.1.1
+store version 1.2.0
 ```
 
 If built without an injected version, the binary reports `dev`.

--- a/README.md
+++ b/README.md
@@ -666,9 +666,9 @@ Global hook layout:
 
 How it works:
 
-- Per-store hooks are configured in YAML and executed with `sh -c`.
-- Global hooks are executable files in `.store/hooks/` and are run directly.
-- Global hook scripts must have the executable bit set; non-executable files are ignored.
+- Per-store hooks are configured in YAML and executed with `sh -c` on Linux and macOS, and with `cmd.exe /C` on Windows.
+- Global hooks live in `.store/hooks/`. On Linux and macOS they must have the executable bit set and are run directly via their shebang.
+- On Windows the executable bit is ignored; global hooks are dispatched by file extension: `.ps1` scripts run under PowerShell, `.cmd`/`.bat`/`.exe` run directly, and anything else is attempted via `sh` (works under Git Bash or WSL).
 
 Relevant details:
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -725,7 +725,13 @@ func TestFindRoot(t *testing.T) {
 				if err != nil {
 					t.Fatalf("FindRoot() error = %v", err)
 				}
-				want := tt.want(cwd)
+				// macOS canonicalizes /var/folders → /private/var/folders on
+				// Chdir, and Windows resolves 8.3 short names; both affect
+				// the path returned by os.Getwd() inside FindRoot.
+				want, err := filepath.EvalSymlinks(tt.want(cwd))
+				if err != nil {
+					t.Fatalf("EvalSymlinks(%q) error = %v", tt.want(cwd), err)
+				}
 				if got != want {
 					t.Fatalf("FindRoot() = %q, want %q", got, want)
 				}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -726,14 +726,18 @@ func TestFindRoot(t *testing.T) {
 					t.Fatalf("FindRoot() error = %v", err)
 				}
 				// macOS canonicalizes /var/folders → /private/var/folders on
-				// Chdir, and Windows resolves 8.3 short names; both affect
-				// the path returned by os.Getwd() inside FindRoot.
-				want, err := filepath.EvalSymlinks(tt.want(cwd))
+				// Chdir, and Windows returns 8.3 short names from Getwd.
+				// Normalize both sides so the comparison is platform-neutral.
+				gotResolved, err := filepath.EvalSymlinks(got)
+				if err != nil {
+					t.Fatalf("EvalSymlinks(%q) error = %v", got, err)
+				}
+				wantResolved, err := filepath.EvalSymlinks(tt.want(cwd))
 				if err != nil {
 					t.Fatalf("EvalSymlinks(%q) error = %v", tt.want(cwd), err)
 				}
-				if got != want {
-					t.Fatalf("FindRoot() = %q, want %q", got, want)
+				if gotResolved != wantResolved {
+					t.Fatalf("FindRoot() = %q, want %q", got, tt.want(cwd))
 				}
 				return
 			}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -37,8 +37,43 @@ func Check(root string) []Issue {
 	issues = append(issues, checkMissingSecrets(root, cfg)...)
 	issues = append(issues, checkEmptyStores(root, cfg)...)
 	issues = append(issues, checkPlatformSkippedStores(cfg, platformInfo)...)
+	issues = append(issues, checkSymlinkCapability(root, platformInfo)...)
 
 	return issues
+}
+
+// checkSymlinkCapability verifies that the current process can create
+// symlinks. On Windows this requires Developer Mode or the
+// SeCreateSymbolicLinkPrivilege; without one of those, os.Symlink returns a
+// permission error at apply time. We probe once so the user sees a clear
+// warning from `store doctor` instead of a cryptic failure later.
+func checkSymlinkCapability(root string, info platform.Info) []Issue {
+	if info.OS != "windows" {
+		return nil
+	}
+
+	dir := filepath.Join(root, ".store")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil
+	}
+
+	target, err := os.CreateTemp(dir, "store-symlink-probe-*")
+	if err != nil {
+		return nil
+	}
+	targetPath := target.Name()
+	_ = target.Close()
+	defer os.Remove(targetPath)
+
+	linkPath := targetPath + ".link"
+	if err := os.Symlink(targetPath, linkPath); err != nil {
+		return []Issue{{
+			Level:   "warning",
+			Message: "cannot create symlinks on this system — enable Windows Developer Mode or run as Administrator",
+		}}
+	}
+	_ = os.Remove(linkPath)
+	return nil
 }
 
 func checkOrphanedConfigEntries(root string, cfg *config.Config) []Issue {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -8,7 +8,38 @@ import (
 
 	"github.com/cushycush/store/internal/config"
 	"github.com/cushycush/store/internal/linker"
+	"github.com/cushycush/store/internal/platform"
 )
+
+func TestCheckSymlinkCapabilityNonWindows(t *testing.T) {
+	root := t.TempDir()
+	// Non-windows info: should be a no-op regardless of actual host.
+	info := platform.Info{OS: "linux"}
+	if issues := checkSymlinkCapability(root, info); len(issues) != 0 {
+		t.Fatalf("expected no issues on non-windows, got %#v", issues)
+	}
+}
+
+func TestCheckSymlinkCapabilityWindows(t *testing.T) {
+	// We can only verify the success path on a host that supports symlinks,
+	// which covers Linux and macOS CI runners. On Windows without Developer
+	// Mode the probe exercises the warning path — either outcome is valid.
+	root := t.TempDir()
+	info := platform.Info{OS: "windows"}
+	issues := checkSymlinkCapability(root, info)
+
+	switch runtime.GOOS {
+	case "linux", "darwin":
+		if len(issues) != 0 {
+			t.Fatalf("expected symlink probe to succeed on %s, got %#v", runtime.GOOS, issues)
+		}
+	}
+	for _, issue := range issues {
+		if issue.Level != "warning" {
+			t.Fatalf("unexpected issue level %q", issue.Level)
+		}
+	}
+}
 
 func TestCheckOrphanedConfigEntry(t *testing.T) {
 	root := t.TempDir()

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -1,6 +1,7 @@
 package doctor
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -81,8 +82,10 @@ func TestCheckBrokenSymlink(t *testing.T) {
 
 	issues := Check(root)
 	assertIssues(t, issues, []Issue{{
-		Level:   "error",
-		Message: `store "nvim" target "` + target + `" has a broken symlink`,
+		Level: "error",
+		// Doctor formats paths with %q, which escapes backslashes on Windows;
+		// mirror that here so this test works on every platform.
+		Message: fmt.Sprintf("store %q target %q has a broken symlink", "nvim", target),
 	}})
 }
 
@@ -101,7 +104,7 @@ func TestCheckConflictingTargets(t *testing.T) {
 	issues := Check(root)
 	assertIssues(t, issues, []Issue{{
 		Level:   "error",
-		Message: `target "` + target + `" is claimed by both store "nvim" and store "nvim-custom"`,
+		Message: fmt.Sprintf("target %q is claimed by both store %q and store %q", target, "nvim", "nvim-custom"),
 	}})
 }
 

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -5,13 +5,21 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strings"
 
 	"github.com/cushycush/store/internal/config"
 	"github.com/cushycush/store/internal/platform"
 )
 
 // RunGlobal executes a global hook script at .store/hooks/<hookName> if it
-// exists and is executable. Returns nil if the hook does not exist.
+// exists. Returns nil if the hook does not exist.
+//
+// On POSIX the script must have the executable bit set and is run directly
+// (relying on its shebang). On Windows the executable bit is ignored and
+// execution is dispatched by file extension: .ps1 scripts run under
+// PowerShell, .cmd/.bat/.exe run directly, and anything else falls back to
+// `sh -c <path>` (useful under Git Bash or WSL).
 func RunGlobal(root, hookName, action string) error {
 	path := filepath.Join(root, ".store", "hooks", hookName)
 
@@ -22,11 +30,11 @@ func RunGlobal(root, hookName, action string) error {
 	if err != nil {
 		return fmt.Errorf("hook %q: %w", hookName, err)
 	}
-	if fi.Mode()&0o111 == 0 {
-		return nil // not executable, skip
-	}
 
-	cmd := exec.Command(path)
+	cmd, ok := buildGlobalHookCmd(path, fi)
+	if !ok {
+		return nil
+	}
 	cmd.Dir = root
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -38,8 +46,9 @@ func RunGlobal(root, hookName, action string) error {
 	return nil
 }
 
-// RunEntry executes a per-store hook command (pre or post) via "sh -c"
-// Returns nil if hooks is nil or the requested phase is empty.
+// RunEntry executes a per-store hook command (pre or post) via the platform's
+// default shell — `cmd.exe /C` on Windows and `sh -c` elsewhere. Returns nil
+// if hooks is nil or the requested phase is empty.
 func RunEntry(root, name, target, action, phase string, h *config.HookEntry) error {
 	if h == nil {
 		return nil
@@ -59,7 +68,7 @@ func RunEntry(root, name, target, action, phase string, h *config.HookEntry) err
 		return nil
 	}
 
-	cmd := exec.Command("sh", "-c", hookCmd)
+	cmd := buildShellCmd(hookCmd)
 	cmd.Dir = root
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -72,6 +81,39 @@ func RunEntry(root, name, target, action, phase string, h *config.HookEntry) err
 		return fmt.Errorf("hook %s (%s) failed: %w", phase, name, err)
 	}
 	return nil
+}
+
+// buildShellCmd constructs the exec.Cmd that runs a hook command string under
+// the platform's default shell.
+func buildShellCmd(hookCmd string) *exec.Cmd {
+	if runtime.GOOS == "windows" {
+		return exec.Command("cmd.exe", "/C", hookCmd)
+	}
+	return exec.Command("sh", "-c", hookCmd)
+}
+
+// buildGlobalHookCmd decides how to execute a global hook script file. It
+// returns (cmd, true) if the script should run, or (nil, false) if it should
+// be silently skipped (e.g. POSIX file without the executable bit).
+func buildGlobalHookCmd(path string, fi os.FileInfo) (*exec.Cmd, bool) {
+	if runtime.GOOS == "windows" {
+		switch strings.ToLower(filepath.Ext(path)) {
+		case ".ps1":
+			return exec.Command("powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", path), true
+		case ".cmd", ".bat", ".exe":
+			return exec.Command(path), true
+		default:
+			// Likely a POSIX-style script with a shebang. `sh` is available
+			// under Git Bash / WSL / MSYS; if it's missing the command will
+			// error at run time and bubble up to the caller.
+			return exec.Command("sh", path), true
+		}
+	}
+
+	if fi.Mode()&0o111 == 0 {
+		return nil, false // not executable, skip
+	}
+	return exec.Command(path), true
 }
 
 func hookEnv(root, action string, extra ...string) []string {

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -83,15 +83,6 @@ func RunEntry(root, name, target, action, phase string, h *config.HookEntry) err
 	return nil
 }
 
-// buildShellCmd constructs the exec.Cmd that runs a hook command string under
-// the platform's default shell.
-func buildShellCmd(hookCmd string) *exec.Cmd {
-	if runtime.GOOS == "windows" {
-		return exec.Command("cmd.exe", "/C", hookCmd)
-	}
-	return exec.Command("sh", "-c", hookCmd)
-}
-
 // buildGlobalHookCmd decides how to execute a global hook script file. It
 // returns (cmd, true) if the script should run, or (nil, false) if it should
 // be silently skipped (e.g. POSIX file without the executable bit).

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -10,81 +10,7 @@ import (
 	"github.com/cushycush/store/internal/platform"
 )
 
-func TestRunGlobal(t *testing.T) {
-	t.Parallel()
-
-	const (
-		hookName = "pre-store"
-		action   = "link"
-	)
-
-	tests := []struct {
-		name    string
-		setup   func(t *testing.T, root string)
-		wantErr bool
-		check   func(t *testing.T, root string)
-	}{
-		{
-			name: "hook exists and is executable",
-			setup: func(t *testing.T, root string) {
-				writeScript(t, filepath.Join(root, ".store", "hooks", hookName), "#!/bin/sh\nenv > \"$STORE_ROOT/hook-env.txt\"\npwd > \"$STORE_ROOT/hook-pwd.txt\"\n", 0o755)
-			},
-			check: func(t *testing.T, root string) {
-				assertFileContains(t, filepath.Join(root, "hook-env.txt"), "STORE_ROOT="+root)
-				assertFileContains(t, filepath.Join(root, "hook-env.txt"), "STORE_ACTION="+action)
-				assertPlatformEnvVars(t, filepath.Join(root, "hook-env.txt"))
-				assertTrimmedFileEquals(t, filepath.Join(root, "hook-pwd.txt"), root)
-			},
-		},
-		{
-			name: "hook does not exist",
-			check: func(t *testing.T, root string) {
-				assertNotExists(t, filepath.Join(root, "hook-env.txt"))
-			},
-		},
-		{
-			name: "hook exists but is not executable",
-			setup: func(t *testing.T, root string) {
-				writeScript(t, filepath.Join(root, ".store", "hooks", hookName), "#!/bin/sh\nenv > \"$STORE_ROOT/hook-env.txt\"\n", 0o644)
-			},
-			check: func(t *testing.T, root string) {
-				assertNotExists(t, filepath.Join(root, "hook-env.txt"))
-			},
-		},
-		{
-			name: "hook fails",
-			setup: func(t *testing.T, root string) {
-				writeScript(t, filepath.Join(root, ".store", "hooks", hookName), "#!/bin/sh\nexit 1\n", 0o755)
-			},
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			root := t.TempDir()
-
-			if tt.setup != nil {
-				tt.setup(t, root)
-			}
-
-			err := RunGlobal(root, hookName, action)
-			if tt.wantErr {
-				if err == nil {
-					t.Fatal("expected error, got nil")
-				}
-			} else if err != nil {
-				t.Fatalf("RunGlobal() error = %v", err)
-			}
-
-			if tt.check != nil {
-				tt.check(t, root)
-			}
-		})
-	}
-}
-
-func TestRunEntry(t *testing.T) {
+func TestRunEntryNilOrEmpty(t *testing.T) {
 	t.Parallel()
 
 	const (
@@ -93,131 +19,35 @@ func TestRunEntry(t *testing.T) {
 		action = "link"
 	)
 
-	tests := []struct {
-		name    string
-		setup   func(t *testing.T, root string) *config.HookEntry
-		invoke  func(t *testing.T, root string, h *config.HookEntry) error
-		wantErr bool
-		check   func(t *testing.T, root string)
-	}{
-		{
-			name: "pre hook runs successfully",
-			setup: func(t *testing.T, root string) *config.HookEntry {
-				path := filepath.Join(root, "pre-hook.sh")
-				writeScript(t, path, "#!/bin/sh\nenv > \"$STORE_ROOT/hook-env.txt\"\n", 0o755)
-				return &config.HookEntry{Pre: path}
-			},
-			invoke: func(t *testing.T, root string, h *config.HookEntry) error {
-				return RunEntry(root, name, target, action, "pre", h)
-			},
-			check: func(t *testing.T, root string) {
-				assertFileContains(t, filepath.Join(root, "hook-env.txt"), "STORE_ROOT="+root)
-				assertFileContains(t, filepath.Join(root, "hook-env.txt"), "STORE_NAME="+name)
-				assertFileContains(t, filepath.Join(root, "hook-env.txt"), "STORE_TARGET="+target)
-				assertFileContains(t, filepath.Join(root, "hook-env.txt"), "STORE_ACTION="+action)
-				assertPlatformEnvVars(t, filepath.Join(root, "hook-env.txt"))
-			},
-		},
-		{
-			name: "post hook runs successfully",
-			setup: func(t *testing.T, root string) *config.HookEntry {
-				path := filepath.Join(root, "post-hook.sh")
-				writeScript(t, path, "#!/bin/sh\ntouch \"$STORE_ROOT/post-ran.txt\"\n", 0o755)
-				return &config.HookEntry{Post: path}
-			},
-			invoke: func(t *testing.T, root string, h *config.HookEntry) error {
-				return RunEntry(root, name, target, action, "post", h)
-			},
-			check: func(t *testing.T, root string) {
-				assertExists(t, filepath.Join(root, "post-ran.txt"))
-			},
-		},
-		{
-			name: "nil hook entry",
-			invoke: func(t *testing.T, root string, h *config.HookEntry) error {
-				return RunEntry(root, name, target, action, "pre", h)
-			},
-		},
-		{
-			name: "empty hook command",
-			setup: func(t *testing.T, root string) *config.HookEntry {
-				return &config.HookEntry{}
-			},
-			invoke: func(t *testing.T, root string, h *config.HookEntry) error {
-				return RunEntry(root, name, target, action, "pre", h)
-			},
-		},
-		{
-			name: "hook fails",
-			setup: func(t *testing.T, root string) *config.HookEntry {
-				path := filepath.Join(root, "fail-hook.sh")
-				writeScript(t, path, "#!/bin/sh\nexit 1\n", 0o755)
-				return &config.HookEntry{Pre: path}
-			},
-			invoke: func(t *testing.T, root string, h *config.HookEntry) error {
-				return RunEntry(root, name, target, action, "pre", h)
-			},
-			wantErr: true,
-		},
-		{
-			name: "unknown phase",
-			setup: func(t *testing.T, root string) *config.HookEntry {
-				return &config.HookEntry{Pre: "printf ignored"}
-			},
-			invoke: func(t *testing.T, root string, h *config.HookEntry) error {
-				return RunEntry(root, name, target, action, "during", h)
-			},
-			wantErr: true,
-		},
-		{
-			name: "pre empty but post set",
-			setup: func(t *testing.T, root string) *config.HookEntry {
-				path := filepath.Join(root, "only-post-hook.sh")
-				writeScript(t, path, "#!/bin/sh\ntouch \"$STORE_ROOT/post-only-ran.txt\"\n", 0o755)
-				return &config.HookEntry{Post: path}
-			},
-			invoke: func(t *testing.T, root string, h *config.HookEntry) error {
-				if err := RunEntry(root, name, target, action, "pre", h); err != nil {
-					return err
-				}
-				return RunEntry(root, name, target, action, "post", h)
-			},
-			check: func(t *testing.T, root string) {
-				assertExists(t, filepath.Join(root, "post-only-ran.txt"))
-			},
-		},
+	t.Run("nil hook entry", func(t *testing.T) {
+		if err := RunEntry(t.TempDir(), name, target, action, "pre", nil); err != nil {
+			t.Fatalf("RunEntry() error = %v", err)
+		}
+	})
+
+	t.Run("empty hook command", func(t *testing.T) {
+		h := &config.HookEntry{}
+		if err := RunEntry(t.TempDir(), name, target, action, "pre", h); err != nil {
+			t.Fatalf("RunEntry() error = %v", err)
+		}
+	})
+
+	t.Run("unknown phase", func(t *testing.T) {
+		h := &config.HookEntry{Pre: "printf ignored"}
+		if err := RunEntry(t.TempDir(), name, target, action, "during", h); err == nil {
+			t.Fatal("expected error for unknown phase, got nil")
+		}
+	})
+}
+
+func TestRunGlobalMissingHook(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	if err := RunGlobal(root, "pre-store", "link"); err != nil {
+		t.Fatalf("RunGlobal() error = %v", err)
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			root := t.TempDir()
-
-			var hooks *config.HookEntry
-			if tt.setup != nil {
-				hooks = tt.setup(t, root)
-			}
-
-			invoke := tt.invoke
-			if invoke == nil {
-				invoke = func(t *testing.T, root string, h *config.HookEntry) error {
-					return RunEntry(root, name, target, action, "pre", h)
-				}
-			}
-
-			err := invoke(t, root, hooks)
-			if tt.wantErr {
-				if err == nil {
-					t.Fatal("expected error, got nil")
-				}
-			} else if err != nil {
-				t.Fatalf("RunEntry() error = %v", err)
-			}
-
-			if tt.check != nil {
-				tt.check(t, root)
-			}
-		})
-	}
+	assertNotExists(t, filepath.Join(root, "hook-env.txt"))
 }
 
 func writeScript(t *testing.T, path, contents string, mode os.FileMode) {

--- a/internal/hooks/hooks_unix_test.go
+++ b/internal/hooks/hooks_unix_test.go
@@ -32,7 +32,13 @@ func TestRunGlobalUnix(t *testing.T) {
 				assertFileContains(t, filepath.Join(root, "hook-env.txt"), "STORE_ROOT="+root)
 				assertFileContains(t, filepath.Join(root, "hook-env.txt"), "STORE_ACTION="+action)
 				assertPlatformEnvVars(t, filepath.Join(root, "hook-env.txt"))
-				assertTrimmedFileEquals(t, filepath.Join(root, "hook-pwd.txt"), root)
+				// macOS `pwd` prints the canonicalized path (/private/var/...)
+				// while t.TempDir() returns the symlinked /var/... form.
+				canonical, err := filepath.EvalSymlinks(root)
+				if err != nil {
+					t.Fatalf("EvalSymlinks(%q) error = %v", root, err)
+				}
+				assertTrimmedFileEquals(t, filepath.Join(root, "hook-pwd.txt"), canonical)
 			},
 		},
 		{

--- a/internal/hooks/hooks_unix_test.go
+++ b/internal/hooks/hooks_unix_test.go
@@ -1,0 +1,182 @@
+//go:build !windows
+
+package hooks
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cushycush/store/internal/config"
+)
+
+func TestRunGlobalUnix(t *testing.T) {
+	t.Parallel()
+
+	const (
+		hookName = "pre-store"
+		action   = "link"
+	)
+
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T, root string)
+		wantErr bool
+		check   func(t *testing.T, root string)
+	}{
+		{
+			name: "hook exists and is executable",
+			setup: func(t *testing.T, root string) {
+				writeScript(t, filepath.Join(root, ".store", "hooks", hookName), "#!/bin/sh\nenv > \"$STORE_ROOT/hook-env.txt\"\npwd > \"$STORE_ROOT/hook-pwd.txt\"\n", 0o755)
+			},
+			check: func(t *testing.T, root string) {
+				assertFileContains(t, filepath.Join(root, "hook-env.txt"), "STORE_ROOT="+root)
+				assertFileContains(t, filepath.Join(root, "hook-env.txt"), "STORE_ACTION="+action)
+				assertPlatformEnvVars(t, filepath.Join(root, "hook-env.txt"))
+				assertTrimmedFileEquals(t, filepath.Join(root, "hook-pwd.txt"), root)
+			},
+		},
+		{
+			name: "hook exists but is not executable",
+			setup: func(t *testing.T, root string) {
+				writeScript(t, filepath.Join(root, ".store", "hooks", hookName), "#!/bin/sh\nenv > \"$STORE_ROOT/hook-env.txt\"\n", 0o644)
+			},
+			check: func(t *testing.T, root string) {
+				assertNotExists(t, filepath.Join(root, "hook-env.txt"))
+			},
+		},
+		{
+			name: "hook fails",
+			setup: func(t *testing.T, root string) {
+				writeScript(t, filepath.Join(root, ".store", "hooks", hookName), "#!/bin/sh\nexit 1\n", 0o755)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+
+			if tt.setup != nil {
+				tt.setup(t, root)
+			}
+
+			err := RunGlobal(root, hookName, action)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+			} else if err != nil {
+				t.Fatalf("RunGlobal() error = %v", err)
+			}
+
+			if tt.check != nil {
+				tt.check(t, root)
+			}
+		})
+	}
+}
+
+func TestRunEntryUnix(t *testing.T) {
+	t.Parallel()
+
+	const (
+		name   = "nvim"
+		target = "~/.config/nvim"
+		action = "link"
+	)
+
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T, root string) *config.HookEntry
+		invoke  func(t *testing.T, root string, h *config.HookEntry) error
+		wantErr bool
+		check   func(t *testing.T, root string)
+	}{
+		{
+			name: "pre hook runs successfully",
+			setup: func(t *testing.T, root string) *config.HookEntry {
+				path := filepath.Join(root, "pre-hook.sh")
+				writeScript(t, path, "#!/bin/sh\nenv > \"$STORE_ROOT/hook-env.txt\"\n", 0o755)
+				return &config.HookEntry{Pre: path}
+			},
+			invoke: func(t *testing.T, root string, h *config.HookEntry) error {
+				return RunEntry(root, name, target, action, "pre", h)
+			},
+			check: func(t *testing.T, root string) {
+				assertFileContains(t, filepath.Join(root, "hook-env.txt"), "STORE_ROOT="+root)
+				assertFileContains(t, filepath.Join(root, "hook-env.txt"), "STORE_NAME="+name)
+				assertFileContains(t, filepath.Join(root, "hook-env.txt"), "STORE_TARGET="+target)
+				assertFileContains(t, filepath.Join(root, "hook-env.txt"), "STORE_ACTION="+action)
+				assertPlatformEnvVars(t, filepath.Join(root, "hook-env.txt"))
+			},
+		},
+		{
+			name: "post hook runs successfully",
+			setup: func(t *testing.T, root string) *config.HookEntry {
+				path := filepath.Join(root, "post-hook.sh")
+				writeScript(t, path, "#!/bin/sh\ntouch \"$STORE_ROOT/post-ran.txt\"\n", 0o755)
+				return &config.HookEntry{Post: path}
+			},
+			invoke: func(t *testing.T, root string, h *config.HookEntry) error {
+				return RunEntry(root, name, target, action, "post", h)
+			},
+			check: func(t *testing.T, root string) {
+				assertExists(t, filepath.Join(root, "post-ran.txt"))
+			},
+		},
+		{
+			name: "hook fails",
+			setup: func(t *testing.T, root string) *config.HookEntry {
+				path := filepath.Join(root, "fail-hook.sh")
+				writeScript(t, path, "#!/bin/sh\nexit 1\n", 0o755)
+				return &config.HookEntry{Pre: path}
+			},
+			invoke: func(t *testing.T, root string, h *config.HookEntry) error {
+				return RunEntry(root, name, target, action, "pre", h)
+			},
+			wantErr: true,
+		},
+		{
+			name: "pre empty but post set",
+			setup: func(t *testing.T, root string) *config.HookEntry {
+				path := filepath.Join(root, "only-post-hook.sh")
+				writeScript(t, path, "#!/bin/sh\ntouch \"$STORE_ROOT/post-only-ran.txt\"\n", 0o755)
+				return &config.HookEntry{Post: path}
+			},
+			invoke: func(t *testing.T, root string, h *config.HookEntry) error {
+				if err := RunEntry(root, name, target, action, "pre", h); err != nil {
+					return err
+				}
+				return RunEntry(root, name, target, action, "post", h)
+			},
+			check: func(t *testing.T, root string) {
+				assertExists(t, filepath.Join(root, "post-only-ran.txt"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+
+			var hooks *config.HookEntry
+			if tt.setup != nil {
+				hooks = tt.setup(t, root)
+			}
+
+			err := tt.invoke(t, root, hooks)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+			} else if err != nil {
+				t.Fatalf("RunEntry() error = %v", err)
+			}
+
+			if tt.check != nil {
+				tt.check(t, root)
+			}
+		})
+	}
+}

--- a/internal/hooks/hooks_windows_test.go
+++ b/internal/hooks/hooks_windows_test.go
@@ -1,0 +1,122 @@
+//go:build windows
+
+package hooks
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cushycush/store/internal/config"
+)
+
+func TestRunGlobalWindows(t *testing.T) {
+	t.Parallel()
+
+	const (
+		hookName = "pre-store.cmd"
+		action   = "link"
+	)
+
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T, root string)
+		wantErr bool
+		check   func(t *testing.T, root string)
+	}{
+		{
+			name: "cmd script runs",
+			setup: func(t *testing.T, root string) {
+				writeScript(t,
+					filepath.Join(root, ".store", "hooks", hookName),
+					"@echo off\r\nset > \"%STORE_ROOT%\\hook-env.txt\"\r\ncd > \"%STORE_ROOT%\\hook-pwd.txt\"\r\n",
+					0o644,
+				)
+			},
+			check: func(t *testing.T, root string) {
+				assertFileContains(t, filepath.Join(root, "hook-env.txt"), "STORE_ROOT="+root)
+				assertFileContains(t, filepath.Join(root, "hook-env.txt"), "STORE_ACTION="+action)
+				assertPlatformEnvVars(t, filepath.Join(root, "hook-env.txt"))
+				assertTrimmedFileEquals(t, filepath.Join(root, "hook-pwd.txt"), root)
+			},
+		},
+		{
+			name: "cmd script fails",
+			setup: func(t *testing.T, root string) {
+				writeScript(t,
+					filepath.Join(root, ".store", "hooks", hookName),
+					"@echo off\r\nexit /b 1\r\n",
+					0o644,
+				)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+
+			if tt.setup != nil {
+				tt.setup(t, root)
+			}
+
+			err := RunGlobal(root, hookName, action)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+			} else if err != nil {
+				t.Fatalf("RunGlobal() error = %v", err)
+			}
+
+			if tt.check != nil {
+				tt.check(t, root)
+			}
+		})
+	}
+}
+
+func TestRunEntryWindows(t *testing.T) {
+	t.Parallel()
+
+	const (
+		name   = "nvim"
+		target = "~/.config/nvim"
+		action = "link"
+	)
+
+	t.Run("pre hook runs via cmd.exe", func(t *testing.T) {
+		root := t.TempDir()
+		h := &config.HookEntry{Pre: `set > "%STORE_ROOT%\hook-env.txt"`}
+
+		if err := RunEntry(root, name, target, action, "pre", h); err != nil {
+			t.Fatalf("RunEntry() error = %v", err)
+		}
+
+		envFile := filepath.Join(root, "hook-env.txt")
+		assertFileContains(t, envFile, "STORE_ROOT="+root)
+		assertFileContains(t, envFile, "STORE_NAME="+name)
+		assertFileContains(t, envFile, "STORE_TARGET="+target)
+		assertFileContains(t, envFile, "STORE_ACTION="+action)
+		assertPlatformEnvVars(t, envFile)
+	})
+
+	t.Run("post hook runs successfully", func(t *testing.T) {
+		root := t.TempDir()
+		h := &config.HookEntry{Post: `type nul > "%STORE_ROOT%\post-ran.txt"`}
+
+		if err := RunEntry(root, name, target, action, "post", h); err != nil {
+			t.Fatalf("RunEntry() error = %v", err)
+		}
+		assertExists(t, filepath.Join(root, "post-ran.txt"))
+	})
+
+	t.Run("failing command returns error", func(t *testing.T) {
+		root := t.TempDir()
+		h := &config.HookEntry{Pre: "exit /b 1"}
+
+		if err := RunEntry(root, name, target, action, "pre", h); err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}

--- a/internal/hooks/shellcmd_unix.go
+++ b/internal/hooks/shellcmd_unix.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package hooks
+
+import "os/exec"
+
+// buildShellCmd runs a per-store hook command under `sh -c`.
+func buildShellCmd(hookCmd string) *exec.Cmd {
+	return exec.Command("sh", "-c", hookCmd)
+}

--- a/internal/hooks/shellcmd_windows.go
+++ b/internal/hooks/shellcmd_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package hooks
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// buildShellCmd runs a per-store hook command under cmd.exe on Windows.
+// It bypasses Go's default Windows argument escaping via SysProcAttr.CmdLine
+// so that quotes the user wrote in their hook command reach cmd.exe
+// verbatim — otherwise `set > "%STORE_ROOT%\foo"` becomes unusable after Go
+// rewrites the inner quotes as `\"`.
+func buildShellCmd(hookCmd string) *exec.Cmd {
+	cmd := exec.Command("cmd.exe")
+	cmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: `/C ` + hookCmd}
+	return cmd
+}

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -216,11 +216,11 @@ func pathWithinRepo(repoRoot, path string) (string, bool) {
 	return rel, true
 }
 
-func portablePath(path string) string {
-	cleaned := filepath.Clean(path)
+func portablePath(p string) string {
+	cleaned := filepath.Clean(p)
 	home, err := os.UserHomeDir()
 	if err != nil || home == "" {
-		return cleaned
+		return filepath.ToSlash(cleaned)
 	}
 
 	home = filepath.Clean(home)
@@ -230,10 +230,13 @@ func portablePath(path string) string {
 
 	prefix := home + string(os.PathSeparator)
 	if suffix, ok := strings.CutPrefix(cleaned, prefix); ok {
-		return filepath.Join("~", suffix)
+		// Config files should use forward slashes so they're readable and
+		// portable across machines; filepath.Join would produce backslashes
+		// on Windows.
+		return "~/" + filepath.ToSlash(suffix)
 	}
 
-	return cleaned
+	return filepath.ToSlash(cleaned)
 }
 
 func sortedKeys(m map[string]struct{}) []string {

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -39,15 +39,40 @@ func TestScanWholeDirectorySymlink(t *testing.T) {
 		t.Fatalf("Scan() error = %v", err)
 	}
 
+	// Scan resolves symlinks and 8.3 short names; mirror that in the expected
+	// values so macOS (/private/var/folders) and Windows (RUNNER~1 vs
+	// runneradmin) comparisons succeed.
+	wantSource := resolvePath(t, storeDir)
 	want := []DiscoveredLink{{
 		StoreName: "nvim",
-		Source:    storeDir,
+		Source:    wantSource,
 		Target:    linkPath,
 		File:      "",
 	}}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("Scan() = %#v, want %#v", got, want)
 	}
+}
+
+// resolvePath returns the canonical path with symlinks and (on Windows) 8.3
+// short names resolved. Scan applies the same transformation internally, so
+// tests that build expected values from t.TempDir() paths must do the same.
+func resolvePath(t *testing.T, path string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%q) error = %v", path, err)
+	}
+	return resolved
+}
+
+// setTestHome points both HOME and USERPROFILE at the given directory so that
+// os.UserHomeDir() (which prefers USERPROFILE on Windows) agrees with the
+// POSIX-style HOME that the tool's config reads.
+func setTestHome(t *testing.T, dir string) {
+	t.Helper()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
 }
 
 func TestScanFileModeSymlinks(t *testing.T) {
@@ -81,8 +106,8 @@ func TestScanFileModeSymlinks(t *testing.T) {
 	}
 
 	want := []DiscoveredLink{
-		{StoreName: "shells", Source: bashrc, Target: filepath.Join(scanDir, ".bashrc"), File: ".bashrc"},
-		{StoreName: "shells", Source: zshrc, Target: filepath.Join(scanDir, ".zshrc"), File: ".zshrc"},
+		{StoreName: "shells", Source: resolvePath(t, bashrc), Target: filepath.Join(scanDir, ".bashrc"), File: ".bashrc"},
+		{StoreName: "shells", Source: resolvePath(t, zshrc), Target: filepath.Join(scanDir, ".zshrc"), File: ".zshrc"},
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("Scan() = %#v, want %#v", got, want)
@@ -118,7 +143,7 @@ func TestScanSkipsNonRepoSymlinksAndRegularFiles(t *testing.T) {
 
 func TestToConfigGroupingAndMixedMode(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setTestHome(t, home)
 	repoRoot := t.TempDir()
 
 	links := []DiscoveredLink{
@@ -175,7 +200,7 @@ func TestToConfigGroupingAndMixedMode(t *testing.T) {
 
 func TestToConfigMultiTargetAndHomePortability(t *testing.T) {
 	home := t.TempDir()
-	t.Setenv("HOME", home)
+	setTestHome(t, home)
 	repoRoot := t.TempDir()
 
 	links := []DiscoveredLink{

--- a/internal/linker/linker_test.go
+++ b/internal/linker/linker_test.go
@@ -210,15 +210,7 @@ func TestLink(t *testing.T) {
 					t.Fatalf("Rel(target): %v", err)
 				}
 
-				// After Chdir(root), Link resolves the relative source via
-				// filepath.Abs which reads os.Getwd — and macOS returns the
-				// canonical /private/var/... form. Mirror that on the expected
-				// side so the readlink comparison succeeds.
-				wantReadlink, err := filepath.EvalSymlinks(sourceAbs)
-				if err != nil {
-					t.Fatalf("EvalSymlinks(%q) error = %v", sourceAbs, err)
-				}
-				return sourceRel, targetRel, wantReadlink
+				return sourceRel, targetRel, sourceAbs
 			},
 		},
 	}
@@ -250,7 +242,19 @@ func TestLink(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Readlink(%q): %v", target, err)
 			}
-			if gotReadlink != wantReadlink {
+			// Normalize via EvalSymlinks so macOS canonicalization
+			// (/private/var/...) and Windows 8.3 short names don't cause
+			// cosmetic mismatches — Link and the expected path may come
+			// from different resolution paths.
+			gotResolved, err := filepath.EvalSymlinks(gotReadlink)
+			if err != nil {
+				t.Fatalf("EvalSymlinks(%q) error = %v", gotReadlink, err)
+			}
+			wantResolved, err := filepath.EvalSymlinks(wantReadlink)
+			if err != nil {
+				t.Fatalf("EvalSymlinks(%q) error = %v", wantReadlink, err)
+			}
+			if gotResolved != wantResolved {
 				t.Fatalf("Readlink(%q) = %q, want %q", target, gotReadlink, wantReadlink)
 			}
 

--- a/internal/linker/linker_test.go
+++ b/internal/linker/linker_test.go
@@ -210,7 +210,15 @@ func TestLink(t *testing.T) {
 					t.Fatalf("Rel(target): %v", err)
 				}
 
-				return sourceRel, targetRel, sourceAbs
+				// After Chdir(root), Link resolves the relative source via
+				// filepath.Abs which reads os.Getwd — and macOS returns the
+				// canonical /private/var/... form. Mirror that on the expected
+				// side so the readlink comparison succeeds.
+				wantReadlink, err := filepath.EvalSymlinks(sourceAbs)
+				if err != nil {
+					t.Fatalf("EvalSymlinks(%q) error = %v", sourceAbs, err)
+				}
+				return sourceRel, targetRel, wantReadlink
 			},
 		},
 	}

--- a/internal/matcher/matcher.go
+++ b/internal/matcher/matcher.go
@@ -15,12 +15,16 @@ var GlobalIgnore = []string{".store", ".store/**", ".git", ".git/**", ".gitignor
 
 // isIgnored checks if a relative path matches any ignore pattern.
 func isIgnored(relPath string, ignorePatterns []string) bool {
+	// doublestar patterns are always forward-slash; normalize the input path
+	// so `.store/config.yaml` matches even when Windows produced
+	// `.store\config.yaml` from filepath.Clean.
+	slashPath := filepath.ToSlash(relPath)
 	for _, pattern := range ignorePatterns {
-		if matched, _ := doublestar.Match(pattern, relPath); matched {
+		if matched, _ := doublestar.Match(pattern, slashPath); matched {
 			return true
 		}
 		dirPattern := strings.TrimSuffix(pattern, "/") + "/**"
-		if matched, _ := doublestar.Match(dirPattern, relPath); matched {
+		if matched, _ := doublestar.Match(dirPattern, slashPath); matched {
 			return true
 		}
 	}

--- a/internal/matcher/matcher_test.go
+++ b/internal/matcher/matcher_test.go
@@ -222,8 +222,11 @@ func assertPathsEqual(t *testing.T, got []string, want []string) {
 		t.Fatalf("Match() returned %v, want %v", got, want)
 	}
 
+	// Match returns paths using the OS-native separator, but test data is
+	// written with forward slashes for readability. Normalize both sides to
+	// forward slashes before comparing so the same table works on Windows.
 	for i := range want {
-		if got[i] != want[i] {
+		if filepath.ToSlash(got[i]) != filepath.ToSlash(want[i]) {
 			t.Fatalf("Match() returned %v, want %v", got, want)
 		}
 	}

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -61,11 +61,35 @@ func (i Info) EnvVars() []string {
 }
 
 func detectShell() string {
-	shell := os.Getenv("SHELL")
-	if shell == "" {
-		return ""
+	return detectShellFromEnv(runtime.GOOS, os.Getenv)
+}
+
+// detectShellFromEnv is the testable core of detectShell. On any OS it first
+// honors $SHELL. On Windows it additionally falls back to PSModulePath
+// (PowerShell) and ComSpec (cmd.exe) when $SHELL is unset.
+func detectShellFromEnv(goos string, getenv func(string) string) string {
+	if shell := getenv("SHELL"); shell != "" {
+		return filepath.Base(shell)
 	}
-	return filepath.Base(shell)
+	if goos == "windows" {
+		if getenv("PSModulePath") != "" {
+			return "powershell"
+		}
+		if comspec := getenv("ComSpec"); comspec != "" {
+			// ComSpec uses Windows separators, so normalize before splitting
+			// rather than relying on host-specific filepath.Base behavior.
+			normalized := strings.ReplaceAll(comspec, `\`, "/")
+			base := normalized
+			if idx := strings.LastIndex(normalized, "/"); idx >= 0 {
+				base = normalized[idx+1:]
+			}
+			if idx := strings.LastIndex(base, "."); idx >= 0 {
+				base = base[:idx]
+			}
+			return strings.ToLower(base)
+		}
+	}
+	return ""
 }
 
 func detectWSL() bool {

--- a/internal/platform/platform_test.go
+++ b/internal/platform/platform_test.go
@@ -53,10 +53,59 @@ func TestDetectShell(t *testing.T) {
 	t.Run("SHELL empty", func(t *testing.T) {
 		t.Setenv("SHELL", "")
 		got := detectShell()
-		if got != "" {
+		if runtime.GOOS != "windows" && got != "" {
 			t.Errorf("detectShell() = %q, want empty", got)
 		}
 	})
+}
+
+func TestDetectShellFromEnv(t *testing.T) {
+	tests := []struct {
+		name string
+		goos string
+		env  map[string]string
+		want string
+	}{
+		{
+			name: "SHELL wins on windows",
+			goos: "windows",
+			env:  map[string]string{"SHELL": "/usr/bin/bash", "PSModulePath": "anything", "ComSpec": `C:\Windows\System32\cmd.exe`},
+			want: "bash",
+		},
+		{
+			name: "windows PSModulePath fallback",
+			goos: "windows",
+			env:  map[string]string{"PSModulePath": `C:\Users\x\Modules`, "ComSpec": `C:\Windows\System32\cmd.exe`},
+			want: "powershell",
+		},
+		{
+			name: "windows ComSpec fallback",
+			goos: "windows",
+			env:  map[string]string{"ComSpec": `C:\Windows\System32\cmd.exe`},
+			want: "cmd",
+		},
+		{
+			name: "windows all empty",
+			goos: "windows",
+			env:  map[string]string{},
+			want: "",
+		},
+		{
+			name: "linux SHELL unset stays empty",
+			goos: "linux",
+			env:  map[string]string{"PSModulePath": "ignored", "ComSpec": "ignored"},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getenv := func(key string) string { return tt.env[key] }
+			if got := detectShellFromEnv(tt.goos, getenv); got != tt.want {
+				t.Errorf("detectShellFromEnv(%q) = %q, want %q", tt.goos, got, tt.want)
+			}
+		})
+	}
 }
 
 func TestEnvVars(t *testing.T) {

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -149,8 +150,17 @@ func TestNeedsRendering(t *testing.T) {
 		{
 			name: "skips directories themselves",
 			setup: func(t *testing.T, dir string) {
-				if err := os.MkdirAll(filepath.Join(dir, "{{ secret \"dir\" }}"), 0o755); err != nil {
-					t.Fatalf("MkdirAll() failed: %v", err)
+				if runtime.GOOS == "windows" {
+					// NTFS disallows `"` in filenames, so fall back to a
+					// template-free directory name that still exercises the
+					// "non-template directory is skipped" path.
+					if err := os.MkdirAll(filepath.Join(dir, "plain-dir"), 0o755); err != nil {
+						t.Fatalf("MkdirAll() failed: %v", err)
+					}
+				} else {
+					if err := os.MkdirAll(filepath.Join(dir, "{{ secret \"dir\" }}"), 0o755); err != nil {
+						t.Fatalf("MkdirAll() failed: %v", err)
+					}
 				}
 				writeTestFile(t, filepath.Join(dir, "plain.txt"), `no secrets here`)
 			},
@@ -200,12 +210,19 @@ func TestStagingDir(t *testing.T) {
 				home := t.TempDir()
 				t.Setenv("XDG_STATE_HOME", "")
 				t.Setenv("HOME", home)
+				// os.UserHomeDir() reads USERPROFILE on Windows; mirror HOME
+				// into it so the fallback computation agrees with the test.
+				t.Setenv("USERPROFILE", home)
 			},
 			makeRoots: func(t *testing.T) (string, string) {
 				return t.TempDir(), ""
 			},
 			wantPrefix: func() string {
-				return filepath.Join(os.Getenv("HOME"), ".local", "state")
+				home := os.Getenv("HOME")
+				if runtime.GOOS == "windows" {
+					home = os.Getenv("USERPROFILE")
+				}
+				return filepath.Join(home, ".local", "state")
 			},
 		},
 		{
@@ -283,7 +300,9 @@ func TestPrepareStaging(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Stat(%q) failed: %v", renderedPath, err)
 				}
-				if info.Mode().Perm() != 0o600 {
+				// Windows doesn't honor POSIX permission bits on os.WriteFile,
+				// so only assert the restrictive 0o600 mode on POSIX.
+				if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
 					t.Fatalf("rendered file mode = %o, want 600", info.Mode().Perm())
 				}
 

--- a/internal/store/secrets_test.go
+++ b/internal/store/secrets_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -160,6 +161,13 @@ func TestStoreTargetWithSecrets(t *testing.T) {
 
 func TestStoreWithSecrets(t *testing.T) {
 	t.Run("hooks use repo root while linking staged source", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			// The hook commands use POSIX `printf` and `$VAR` expansion which
+			// aren't native to cmd.exe. The platform-agnostic behavior (hooks
+			// receive STORE_ROOT/NAME/TARGET/ACTION) is covered by
+			// internal/hooks/hooks_windows_test.go.
+			t.Skip("uses POSIX shell syntax; equivalent coverage lives in hooks_windows_test.go")
+		}
 		root := t.TempDir()
 		createStore(t, root, "app", map[string]string{"config.toml": testTemplateContent})
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -37,17 +37,6 @@ func writeTestFile(t *testing.T, path, content string) {
 	}
 }
 
-func createExecutableScript(t *testing.T, root, rel, body string) string {
-	t.Helper()
-
-	path := filepath.Join(root, rel)
-	writeTestFile(t, path, "#!/bin/sh\n"+body+"\n")
-	if err := os.Chmod(path, 0o755); err != nil {
-		t.Fatalf("Chmod(%q): %v", path, err)
-	}
-	return path
-}
-
 func mustSymlink(t *testing.T, target, linkPath string) {
 	t.Helper()
 
@@ -348,10 +337,12 @@ func TestStore(t *testing.T) {
 			setup: func(t *testing.T, root string) config.StoreEntry {
 				t.Helper()
 				createStore(t, root, "app", map[string]string{"config.txt": "data"})
-				script := createExecutableScript(t, root, filepath.Join("scripts", "pre-fail.sh"), "exit 1")
+				// `exit 1` is valid in both sh -c and cmd.exe /C, so this
+				// exercises the abort path on every platform without needing
+				// a shell-script file with a platform-specific shebang.
 				return config.StoreEntry{
 					Target: filepath.Join(root, "targets", "app"),
-					Hooks:  &config.HookEntry{Pre: script},
+					Hooks:  &config.HookEntry{Pre: "exit 1"},
 				}
 			},
 			wantErr: "hook pre (app) failed",
@@ -365,10 +356,9 @@ func TestStore(t *testing.T) {
 			setup: func(t *testing.T, root string) config.StoreEntry {
 				t.Helper()
 				createStore(t, root, "app", map[string]string{"config.txt": "data"})
-				script := createExecutableScript(t, root, filepath.Join("scripts", "post-fail.sh"), "exit 1")
 				return config.StoreEntry{
 					Target: filepath.Join(root, "targets", "app"),
-					Hooks:  &config.HookEntry{Post: script},
+					Hooks:  &config.HookEntry{Post: "exit 1"},
 				}
 			},
 			check: func(t *testing.T, root string, entry config.StoreEntry) {
@@ -630,8 +620,7 @@ func TestStoreRemove(t *testing.T) {
 				if err := Store(root, "app", base); err != nil {
 					t.Fatalf("Store() setup error: %v", err)
 				}
-				script := createExecutableScript(t, root, filepath.Join("scripts", "unlink-pre-fail.sh"), "exit 1")
-				base.Hooks = &config.HookEntry{Pre: script}
+				base.Hooks = &config.HookEntry{Pre: "exit 1"}
 				return base
 			},
 			wantErr: "hook pre (app) failed",
@@ -649,8 +638,7 @@ func TestStoreRemove(t *testing.T) {
 				if err := Store(root, "app", base); err != nil {
 					t.Fatalf("Store() setup error: %v", err)
 				}
-				script := createExecutableScript(t, root, filepath.Join("scripts", "unlink-post-fail.sh"), "exit 1")
-				base.Hooks = &config.HookEntry{Post: script}
+				base.Hooks = &config.HookEntry{Post: "exit 1"}
 				return base
 			},
 			check: func(t *testing.T, root string, entry config.StoreEntry) {


### PR DESCRIPTION
## Summary

Brings the CLI to parity on Windows and wires up CI coverage for all three major platforms. The scope grew from the original plan once the new CI matrix exposed a pile of pre-existing test bugs (never visible before because the suite had only ever run on Linux); this PR fixes those in addition to the Windows feature work so `main` stays green across the matrix.

### Feature changes (Windows support)

- **Shell detection** (`internal/platform`): on Windows, fall back to `PSModulePath` (→ `powershell`) and `ComSpec` (→ `cmd`) when `$SHELL` is unset. `$SHELL` still wins when present so WSL / Git Bash keep reporting their actual shell. Core logic extracted into `detectShellFromEnv` and covered by table-driven tests that simulate each OS without touching the host.
- **Hook execution** (`internal/hooks`):
  - Per-store hooks now run under `cmd.exe /C` on Windows and `sh -c` elsewhere. The Windows variant uses `SysProcAttr.CmdLine` to bypass Go's automatic argument escaping — otherwise a hook like `set > "%STORE_ROOT%\foo"` turns into `set > \"%STORE_ROOT%\foo\"` which cmd.exe rejects.
  - Global hooks in `.store/hooks/` are dispatched by file extension on Windows (`.ps1` → PowerShell with `-NoProfile -ExecutionPolicy Bypass`, `.cmd`/`.bat`/`.exe` → run directly, anything else → `sh <path>` for Git Bash/WSL). POSIX behavior is unchanged: the executable bit still gates execution.
  - Tests split by build tag — shared nil/empty/unknown-phase cases stay in `hooks_test.go`, POSIX shebang + exec-bit coverage moves to `hooks_unix_test.go`, and new `hooks_windows_test.go` exercises the `cmd.exe` paths with real `.cmd` scripts.
- **Doctor symlink probe** (`internal/doctor`): on Windows, `store doctor` now creates a temp file in `.store/` and tries `os.Symlink`; if that fails it surfaces a warning pointing the user at Developer Mode / Administrator. Silent no-op on other OSes.
- **CI** (`.github/workflows/test.yml`): new matrix workflow running `go test ./...` and `go build ./cmd/store` on `ubuntu-latest`, `macos-latest`, and `windows-latest` for every push to main and every PR. `fail-fast: false` so one platform's failure doesn't mask the others.
- **Version bump**: Makefile default and README install/version examples now point at `v1.2.0`.

### Cross-platform test fixes (uncovered by new CI)

- **macOS**: `/var/folders/...` is a symlink to `/private/var/folders/...`. Tests in `config`, `hooks_unix`, `importer`, and `linker` compared raw tempdir paths against canonicalized ones. Normalize via `filepath.EvalSymlinks` on the comparison sides.
- **Windows path separators**: `internal/matcher` tests used forward-slash literals; switched `assertPathsEqual` to compare via `filepath.ToSlash` so the table works unmodified. Fixed `isIgnored` (production) to pass `filepath.ToSlash(relPath)` to `doublestar.Match` so `.store/config.yaml` is excluded even when Windows produced `.store\config.yaml`.
- **Windows 8.3 short names**: `t.TempDir()` can return `C:\Users\RUNNER~1\...` while `filepath.EvalSymlinks` and `os.UserHomeDir` return the long form `C:\Users\runneradmin\...`. `TestFindRoot` and `TestLink` now `EvalSymlinks` both sides of the comparison.
- **Windows home-dir env**: `os.UserHomeDir` reads `USERPROFILE` on Windows, not `HOME`. Importer and render tests now set both env vars so the tool's home resolution agrees with the test's expected home.
- **Windows NTFS**: skip the render test that uses `{{ secret "dir" }}` as a directory name (invalid on NTFS) and skip POSIX perm assertions in render (no POSIX mode semantics on Windows).
- **Windows shell semantics**: replaced POSIX-script-file-based hook-failure tests in `store` with a plain `"exit 1"` command string (valid in both `sh -c` and `cmd.exe /C`). Skipped the secrets-integration hook test on Windows (uses `printf`/`$VAR` syntax) — equivalent coverage exists in `hooks_windows_test.go`.
- **Doctor message format**: `doctor` formats paths with `%q`, which escapes backslashes on Windows; tests now build their expected messages the same way instead of via raw string concat.
- **Importer portable paths**: `portablePath` used `filepath.Join("~", suffix)` which on Windows produced `~\.config\git`. Configs are meant to be portable across machines, so switched to forward-slash construction via `filepath.ToSlash`.

## Test plan

- [x] `go test ./...` green locally (linux)
- [x] Matrix CI green on ubuntu-latest
- [x] Matrix CI green on macos-latest
- [x] Matrix CI green on windows-latest
- [ ] After merge: tag `v1.2.0` on main and confirm `release.yml` publishes the five cross-compiled zips