### PR TITLE
Fix repository URL in build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Example result after running `store`:
 ### go install
 
 ```sh
-$ go install github.com/cush/store/cmd/store@latest
+$ go install github.com/cushycush/store/cmd/store@latest
 ```
 
 ### Build from source

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ $ go install github.com/cush/store/cmd/store@latest
 ### Build from source
 
 ```sh
-$ git clone https://github.com/cush/store.git
+$ git clone https://github.com/cushycush/store.git
 $ cd store
 $ make build VERSION=1.2.2
 $ mv store /usr/local/bin/


### PR DESCRIPTION
Somewhat of an odd mistake, but your GitHub username is incorrect in the README's install instructions.