### PR TITLE
Add store adopt command

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Example result after running `store`:
 | **Shell completion**         | Shell-specific setup outside the tool                   | `store completion` generates scripts for major shells              |
 | **Health checks (doctor)**   | No built-in diagnostics command                         | `store doctor` checks config, targets, secrets, and platform skips |
 | **Import existing symlinks** | No import command                                       | `store import` scans existing symlinks and writes config           |
+| **Adopt existing files**     | Manual move-and-link workflow                           | `store adopt` moves files into the repo and symlinks back          |
 | **Dry run preview**          | No built-in preview command                             | `store diff` shows create/replace/conflict actions before changes  |
 
 ## Installation
@@ -99,7 +100,13 @@ $ git init
 $ store init
 ```
 
-2. Add a whole-directory store:
+2. Adopt an existing config directory (moves it into the repo and symlinks back):
+
+```sh
+$ store adopt ~/.config/nvim
+```
+
+   Or create a store manually and point it at a target:
 
 ```sh
 $ store add nvim -t ~/.config/nvim
@@ -535,6 +542,41 @@ Relevant details:
 
 - Without `--dry-run`, `store import` prints the discovered mapping and asks for confirmation before writing config.
 - The persistent `--force` flag skips that confirmation prompt.
+
+### `store adopt <path>`
+
+Takes an existing file or directory, moves it into the repo, creates a config entry, and symlinks back to the original location.
+
+| Flag         | Short | Description                                                 |
+| ------------ | ----- | ----------------------------------------------------------- |
+| `--name`     | `-n`  | Override the derived store name                             |
+| `--dry-run`  |       | Preview what would happen without making changes            |
+| `--files`    | `-f`  | Only adopt specific files from a directory; repeatable      |
+| `--patterns` | `-p`  | Only adopt files matching glob patterns; repeatable         |
+
+```sh
+$ store adopt ~/.config/nvim
+$ store adopt ~/.zshrc
+$ store adopt ~/.config/nvim --name vim
+$ store adopt ~/.config/app -f config.toml -f settings.json
+$ store adopt ~/.config/nvim --dry-run
+```
+
+```text
+$ store adopt ~/.config/nvim
+Adopting:
+  ~/.config/nvim -> nvim/ (directory)
+Proceed? [y/N] y
+  nvim -> ~/.config/nvim
+```
+
+How it works:
+
+- Directories are moved whole into the repo and symlinked back.
+- Single files are placed into a store directory named after the file (leading dots stripped), with the target set to the file's parent directory.
+- The store name is derived from the path basename. Use `--name` to override.
+- `--files` and `--patterns` adopt only matching files from a directory, creating a file-mode store entry.
+- Rejects paths that are already symlinks — use `store import` for those.
 
 ### `store add <name>`
 

--- a/cmd/store/adopt_ops.go
+++ b/cmd/store/adopt_ops.go
@@ -1,0 +1,238 @@
+package main
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/cushycush/store/internal/config"
+	"github.com/cushycush/store/internal/linker"
+	"github.com/cushycush/store/internal/ui"
+)
+
+func runAdopt(path, name string, dryRun bool, files, patterns []string) error {
+	root, cfg, err := findRootAndConfig()
+	if err != nil {
+		return err
+	}
+
+	// Resolve the source path.
+	expanded, err := config.ExpandHome(path)
+	if err != nil {
+		return fmt.Errorf("failed to expand path: %w", err)
+	}
+	absPath, err := filepath.Abs(expanded)
+	if err != nil {
+		return fmt.Errorf("failed to resolve path: %w", err)
+	}
+
+	fi, err := os.Lstat(absPath)
+	if err != nil {
+		return fmt.Errorf("path does not exist: %s", absPath)
+	}
+
+	if fi.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%s is already a symlink (use 'store import' for existing symlinks)", absPath)
+	}
+
+	isDir := fi.IsDir()
+
+	// Derive the store name.
+	if name == "" {
+		name = deriveStoreName(absPath)
+	}
+
+	if _, exists := cfg.Stores[name]; exists {
+		return fmt.Errorf("store %q already exists (use 'store modify' to update it)", name)
+	}
+
+	// Check that the store directory doesn't already exist in the repo.
+	storePath := filepath.Join(root, name)
+	if _, err := os.Stat(storePath); err == nil {
+		return fmt.Errorf("directory %q already exists in repo", name)
+	}
+
+	// Build the config entry and determine what will be moved.
+	targetPath, err := resolveTargetPath(path)
+	if err != nil {
+		return err
+	}
+
+	var entry config.StoreEntry
+	var moveItems []moveItem
+
+	if isDir {
+		if len(files) > 0 || len(patterns) > 0 {
+			// File-mode adoption: only adopt specific files from the directory.
+			entry = config.StoreEntry{Target: targetPath, Files: files, Patterns: patterns}
+			items, err := collectFileMoveItems(absPath, files, patterns)
+			if err != nil {
+				return err
+			}
+			moveItems = items
+		} else {
+			// Whole-directory adoption.
+			entry = config.StoreEntry{Target: targetPath}
+			moveItems = []moveItem{{source: absPath, dest: storePath, isDir: true}}
+		}
+	} else {
+		// Single file adoption: store name directory holds the file,
+		// target is the parent directory, files list is just the filename.
+		fileName := filepath.Base(absPath)
+		parentDir := filepath.Dir(absPath)
+		targetPath, err = resolveTargetPath(parentDir)
+		if err != nil {
+			return err
+		}
+		entry = config.StoreEntry{Target: targetPath, Files: []string{fileName}}
+		moveItems = []moveItem{{
+			source: absPath,
+			dest:   filepath.Join(storePath, fileName),
+		}}
+	}
+
+	// Print what we'll do.
+	fmt.Println(ui.Bold("Adopting:"))
+	if isDir && (len(files) > 0 || len(patterns) > 0) {
+		for _, item := range moveItems {
+			rel, _ := filepath.Rel(absPath, item.source)
+			fmt.Printf("  %s %s %s %s\n", ui.TargetPath(filepath.Join(path, rel)), ui.Arrow(), ui.StoreName(name+"/"+rel), ui.Dim("(file)"))
+		}
+	} else if isDir {
+		fmt.Printf("  %s %s %s %s\n", ui.TargetPath(path), ui.Arrow(), ui.StoreName(name+"/"), ui.Dim("(directory)"))
+	} else {
+		fmt.Printf("  %s %s %s %s\n", ui.TargetPath(path), ui.Arrow(), ui.StoreName(name+"/"+filepath.Base(absPath)), ui.Dim("(file)"))
+	}
+
+	if dryRun {
+		fmt.Printf("\n%s\n", ui.Dim("Dry run: no changes made"))
+		return nil
+	}
+
+	if !forceBackups && !promptYesNo("Proceed?") {
+		return fmt.Errorf("aborted")
+	}
+
+	// Execute the adoption.
+	if err := executeMoves(storePath, moveItems); err != nil {
+		return err
+	}
+
+	// Write config.
+	cfg.Stores[name] = entry
+	if err := config.Save(root, cfg); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+
+	// Create symlinks.
+	if isDir && len(files) == 0 && len(patterns) == 0 {
+		// Whole-directory: symlink the directory itself.
+		if err := linker.Link(storePath, absPath); err != nil {
+			return fmt.Errorf("failed to create symlink: %w", err)
+		}
+	} else {
+		// File mode: symlink each file.
+		for _, item := range moveItems {
+			if err := linker.Link(item.dest, item.source); err != nil {
+				return fmt.Errorf("failed to create symlink for %s: %w", item.source, err)
+			}
+		}
+	}
+
+	printStoredTarget(name, entry.Target, entry.HasFileMode())
+	return nil
+}
+
+type moveItem struct {
+	source string // original location (will become the symlink)
+	dest   string // destination in repo
+	isDir  bool
+}
+
+// deriveStoreName extracts a store name from a path.
+// It strips leading dots from the basename so ~/.zshrc becomes "zshrc".
+func deriveStoreName(absPath string) string {
+	base := filepath.Base(absPath)
+	return strings.TrimLeft(base, ".")
+}
+
+// collectFileMoveItems resolves explicit files and patterns against a directory
+// and returns the list of individual files to move.
+func collectFileMoveItems(dir string, files, patterns []string) ([]moveItem, error) {
+	seen := make(map[string]bool)
+	var items []moveItem
+
+	for _, f := range files {
+		abs := filepath.Join(dir, f)
+		if _, err := os.Lstat(abs); err != nil {
+			return nil, fmt.Errorf("file %q not found in %s", f, dir)
+		}
+		if !seen[f] {
+			seen[f] = true
+			items = append(items, moveItem{source: abs, dest: ""}) // dest set during execute
+		}
+	}
+
+	for _, pattern := range patterns {
+		err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return err
+			}
+			rel, _ := filepath.Rel(dir, path)
+			matched, matchErr := filepath.Match(pattern, rel)
+			if matchErr != nil {
+				return matchErr
+			}
+			// Also try matching just the filename for simple patterns.
+			if !matched {
+				matched, _ = filepath.Match(pattern, filepath.Base(rel))
+			}
+			if matched && !seen[rel] {
+				seen[rel] = true
+				items = append(items, moveItem{source: path, dest: ""})
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, fmt.Errorf("pattern %q: %w", pattern, err)
+		}
+	}
+
+	if len(items) == 0 {
+		return nil, fmt.Errorf("no files matched in %s", dir)
+	}
+
+	return items, nil
+}
+
+// executeMoves moves source files/directories into the repo store directory.
+func executeMoves(storePath string, items []moveItem) error {
+	for i, item := range items {
+		if item.isDir {
+			// Whole directory: rename directly to store path.
+			if err := os.Rename(item.source, storePath); err != nil {
+				return fmt.Errorf("failed to move %s to %s: %w", item.source, storePath, err)
+			}
+			continue
+		}
+
+		// Individual file: ensure dest is set and parent dirs exist.
+		dest := item.dest
+		if dest == "" {
+			rel, _ := filepath.Rel(filepath.Dir(item.source), item.source)
+			dest = filepath.Join(storePath, rel)
+			items[i].dest = dest
+		}
+
+		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+			return fmt.Errorf("failed to create directory for %s: %w", dest, err)
+		}
+		if err := os.Rename(item.source, dest); err != nil {
+			return fmt.Errorf("failed to move %s to %s: %w", item.source, dest, err)
+		}
+	}
+
+	return nil
+}

--- a/cmd/store/commands.go
+++ b/cmd/store/commands.go
@@ -23,6 +23,7 @@ func newRootCmd() *cobra.Command {
 	rootCmd.AddCommand(
 		newInitCmd(),
 		newImportCmd(),
+		newAdoptCmd(),
 		newAddCmd(),
 		newModifyCmd(),
 		newRemoveCmd(),
@@ -63,6 +64,39 @@ func newImportCmd() *cobra.Command {
 
 	cmd.Flags().StringArrayVar(&scanDirs, "scan-dir", nil, "directories to scan for symlinks (default: ~, ~/.config, ~/.local/share, ~/.local/bin)")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print discovered imports without writing config")
+
+	return cmd
+}
+
+func newAdoptCmd() *cobra.Command {
+	var name string
+	var dryRun bool
+	var files []string
+	var patterns []string
+
+	cmd := &cobra.Command{
+		Use:   "adopt <path>",
+		Short: "Adopt an existing file or directory into the store",
+		Long: `Takes an existing file or directory, moves it into the repo, creates a
+config entry, and symlinks back to the original location.
+
+The store name is derived from the path basename (leading dots stripped).
+Use --name to override the derived name.
+
+Examples:
+  store adopt ~/.config/nvim            # adopts whole directory as "nvim"
+  store adopt ~/.zshrc                  # adopts single file as "zshrc"
+  store adopt ~/.config/nvim --name vim # adopts as "vim" instead of "nvim"`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runAdopt(args[0], name, dryRun, files, patterns)
+		},
+	}
+
+	cmd.Flags().StringVarP(&name, "name", "n", "", "override the derived store name")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "preview what would happen without making changes")
+	cmd.Flags().StringArrayVarP(&files, "files", "f", nil, "only adopt specific files from a directory (repeatable)")
+	cmd.Flags().StringArrayVarP(&patterns, "patterns", "p", nil, "only adopt files matching glob patterns (repeatable)")
 
 	return cmd
 }

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -14,6 +14,9 @@ func init() {
 		enabled = false
 		return
 	}
+	if os.Getenv("FORCE_COLOR") != "" {
+		return
+	}
 	if !term.IsTerminal(int(os.Stdout.Fd())) {
 		enabled = false
 	}

--- a/test.sh
+++ b/test.sh
@@ -46,19 +46,17 @@ vlog() {
 is_symlink()    { [[ -L "$1" ]]; }
 not_exists()    { [[ ! -e "$1" ]] && [[ ! -L "$1" ]]; }
 
-# Run a store command; in verbose mode, display the command and its output
-# to the terminal (fd 3) while still emitting raw output on stdout for callers.
+# Run a store command; in verbose mode, show the command and its raw output
+# (preserving store's UI colors) on the terminal via fd 3.
 S() {
     if [[ $VERBOSE -eq 1 ]]; then
-        printf '    %s\n' "$(dim "\$ store $*")" >&3
+        printf '\n    %s\n' "$(dim "\$ store $*")" >&3
         local tmpout
         tmpout=$(mktemp)
         "$STORE_BIN" "$@" > "$tmpout" 2>&1
         local rc=$?
         if [[ -s "$tmpout" ]]; then
-            while IFS= read -r line; do
-                printf '    %s\n' "$(dim "  $line")" >&3
-            done < "$tmpout"
+            sed 's/^/    /' "$tmpout" >&3
         fi
         cat "$tmpout"
         rm -f "$tmpout"

--- a/test.sh
+++ b/test.sh
@@ -32,28 +32,36 @@ bold()  { printf '\033[1m%s\033[0m' "$*"; }
 pass() { PASS=$((PASS + 1)); printf '  %s %s\n' "$(green '✓')" "$1"; }
 fail() { FAIL=$((FAIL + 1)); printf '  %s %s — %s\n' "$(red '✗')" "$1" "$2"; }
 
+# Save original stdout so verbose output always reaches the terminal,
+# even when callers redirect S() output (e.g. >/dev/null or $(...)).
+exec 3>&1
+
 # Log a verbose message describing what the test is doing.
 vlog() {
     if [[ $VERBOSE -eq 1 ]]; then
-        printf '    %s\n' "$(dim "$*")"
+        printf '    %s\n' "$(dim "$*")" >&3
     fi
 }
 
 is_symlink()    { [[ -L "$1" ]]; }
 not_exists()    { [[ ! -e "$1" ]] && [[ ! -L "$1" ]]; }
 
-# Run a store command; in verbose mode, display the command and its output.
+# Run a store command; in verbose mode, display the command and its output
+# to the terminal (fd 3) while still emitting raw output on stdout for callers.
 S() {
     if [[ $VERBOSE -eq 1 ]]; then
-        printf '    %s\n' "$(dim "\$ store $*")"
-        local out
-        out=$("$STORE_BIN" "$@" 2>&1)
+        printf '    %s\n' "$(dim "\$ store $*")" >&3
+        local tmpout
+        tmpout=$(mktemp)
+        "$STORE_BIN" "$@" > "$tmpout" 2>&1
         local rc=$?
-        if [[ -n "$out" ]]; then
+        if [[ -s "$tmpout" ]]; then
             while IFS= read -r line; do
-                printf '    %s\n' "$(dim "  $line")"
-            done <<< "$out"
+                printf '    %s\n' "$(dim "  $line")" >&3
+            done < "$tmpout"
         fi
+        cat "$tmpout"
+        rm -f "$tmpout"
         return $rc
     else
         "$STORE_BIN" "$@"

--- a/test.sh
+++ b/test.sh
@@ -7,20 +7,58 @@ set -uo pipefail
 # Usage:
 #   ./test.sh              # build and test
 #   ./test.sh ./store      # test an existing binary
+#   ./test.sh -v           # verbose: show all command output
+#   ./test.sh -v ./store   # verbose with existing binary
 
 PASS=0
 FAIL=0
+VERBOSE=0
+
+# Parse flags.
+args=()
+for arg in "$@"; do
+    case "$arg" in
+        -v|--verbose) VERBOSE=1 ;;
+        *) args+=("$arg") ;;
+    esac
+done
+set -- "${args[@]+"${args[@]}"}"
 
 red()   { printf '\033[1;31m%s\033[0m' "$*"; }
 green() { printf '\033[1;32m%s\033[0m' "$*"; }
+dim()   { printf '\033[2m%s\033[0m' "$*"; }
 bold()  { printf '\033[1m%s\033[0m' "$*"; }
 
 pass() { PASS=$((PASS + 1)); printf '  %s %s\n' "$(green '✓')" "$1"; }
 fail() { FAIL=$((FAIL + 1)); printf '  %s %s — %s\n' "$(red '✗')" "$1" "$2"; }
 
+# Log a verbose message describing what the test is doing.
+vlog() {
+    if [[ $VERBOSE -eq 1 ]]; then
+        printf '    %s\n' "$(dim "$*")"
+    fi
+}
+
 is_symlink()    { [[ -L "$1" ]]; }
 not_exists()    { [[ ! -e "$1" ]] && [[ ! -L "$1" ]]; }
-S() { "$STORE_BIN" "$@"; }
+
+# Run a store command; in verbose mode, display the command and its output.
+S() {
+    if [[ $VERBOSE -eq 1 ]]; then
+        printf '    %s\n' "$(dim "\$ store $*")"
+        local out
+        out=$("$STORE_BIN" "$@" 2>&1)
+        local rc=$?
+        if [[ -n "$out" ]]; then
+            while IFS= read -r line; do
+                printf '    %s\n' "$(dim "  $line")"
+            done <<< "$out"
+        fi
+        return $rc
+    else
+        "$STORE_BIN" "$@"
+    fi
+}
 
 STORE_BIN="${1:-}"
 if [[ -z "$STORE_BIN" ]]; then
@@ -46,9 +84,11 @@ cd "$REPO"
 printf '\n%s\n' "$(bold '=== store init ===')"
 # ============================================================
 
+vlog "Initializing store in $REPO"
 S init >/dev/null 2>&1
 if [[ -f .store/config.yaml ]]; then pass "init creates .store/config.yaml"; else fail "init creates .store/config.yaml" "missing config"; fi
 
+vlog "Attempting duplicate init (should fail)"
 if S init >/dev/null 2>&1; then fail "init fails if already initialized" "should have failed"; else pass "init fails if already initialized"; fi
 
 # ============================================================
@@ -66,10 +106,12 @@ printf '\n%s\n' "$(bold '=== store add (whole directory) ===')"
 # ============================================================
 
 TARGET_NVIM="$TMPDIR_ROOT/targets/nvim"
+vlog "Creating nvim directory with init.lua and lua/plugins.lua"
 mkdir -p "$REPO/nvim/lua"
 echo "vim.opt.number = true" > "$REPO/nvim/init.lua"
 echo "return {}" > "$REPO/nvim/lua/plugins.lua"
 
+vlog "Adding nvim store targeting $TARGET_NVIM"
 S add nvim -t "$TARGET_NVIM" >/dev/null 2>&1
 if is_symlink "$TARGET_NVIM"; then pass "add creates whole-directory symlink"; else fail "add creates whole-directory symlink" "not a symlink"; fi
 
@@ -87,11 +129,13 @@ printf '\n%s\n' "$(bold '=== store add (file mode — explicit files) ===')"
 # ============================================================
 
 TARGET_SHELLS="$TMPDIR_ROOT/targets/shells"
+vlog "Creating shells directory with .zshrc, .bashrc, config.fish"
 mkdir -p "$TARGET_SHELLS" "$REPO/shells"
 echo 'export ZSH=true' > "$REPO/shells/.zshrc"
 echo 'export BASH=true' > "$REPO/shells/.bashrc"
 echo 'set fish' > "$REPO/shells/config.fish"
 
+vlog "Adding shells store with explicit files .zshrc and .bashrc"
 S add shells -t "$TARGET_SHELLS" -f .zshrc -f .bashrc >/dev/null 2>&1
 if is_symlink "$TARGET_SHELLS/.zshrc" && is_symlink "$TARGET_SHELLS/.bashrc"; then
     pass "add with -f creates per-file symlinks"
@@ -106,11 +150,13 @@ printf '\n%s\n' "$(bold '=== store add (file mode — glob patterns) ===')"
 # ============================================================
 
 TARGET_CONFIGS="$TMPDIR_ROOT/targets/configs"
+vlog "Creating configs directory with app.conf, sub/db.conf, readme.txt"
 mkdir -p "$REPO/configs/sub"
 echo "a" > "$REPO/configs/app.conf"
 echo "b" > "$REPO/configs/sub/db.conf"
 echo "c" > "$REPO/configs/readme.txt"
 
+vlog "Adding configs store with pattern **/*.conf"
 S add configs -t "$TARGET_CONFIGS" -p "**/*.conf" >/dev/null 2>&1
 if is_symlink "$TARGET_CONFIGS/app.conf" && is_symlink "$TARGET_CONFIGS/sub/db.conf"; then
     pass "add with -p creates pattern-matched symlinks"
@@ -155,6 +201,7 @@ printf '\n%s\n' "$(bold '=== store modify ===')"
 TARGET_SHELLS2="$TMPDIR_ROOT/targets/shells2"
 mkdir -p "$TARGET_SHELLS2"
 
+vlog "Modifying shells store: changing target to $TARGET_SHELLS2, keeping only .zshrc"
 S modify shells -t "$TARGET_SHELLS2" -f .zshrc >/dev/null 2>&1
 if is_symlink "$TARGET_SHELLS2/.zshrc"; then pass "modify changes target and relinks"; else fail "modify changes target and relinks" "new target not linked"; fi
 
@@ -169,15 +216,19 @@ TARGET_NU="$TMPDIR_ROOT/targets/nu"
 mkdir -p "$TARGET_FISH" "$TARGET_NU"
 echo 'set nu' > "$REPO/shells/config.nu"
 
+vlog "Adding fish target to shells store"
 S target add shells -t "$TARGET_FISH" -f config.fish >/dev/null 2>&1
 if is_symlink "$TARGET_FISH/config.fish"; then pass "target add creates multi-target store"; else fail "target add creates multi-target store" "not linked"; fi
 
+vlog "Adding nu target to shells store"
 S target add shells -t "$TARGET_NU" -f config.nu >/dev/null 2>&1
 if is_symlink "$TARGET_NU/config.nu"; then pass "target add second target"; else fail "target add second target" "not linked"; fi
 
+vlog "Modifying fish target files"
 S target modify shells -t "$TARGET_FISH" -f config.fish >/dev/null 2>&1
 if is_symlink "$TARGET_FISH/config.fish"; then pass "target modify updates files"; else fail "target modify updates files" "failed"; fi
 
+vlog "Removing nu target from shells store"
 S target remove shells -t "$TARGET_NU" >/dev/null 2>&1
 if not_exists "$TARGET_NU/config.nu"; then pass "target remove unlinks and removes target"; else fail "target remove unlinks and removes target" "symlink still exists"; fi
 
@@ -185,9 +236,11 @@ if not_exists "$TARGET_NU/config.nu"; then pass "target remove unlinks and remov
 printf '\n%s\n' "$(bold '=== store remove / removeall ===')"
 # ============================================================
 
+vlog "Removing configs store"
 S remove configs >/dev/null 2>&1
 if not_exists "$TARGET_CONFIGS/app.conf"; then pass "remove deletes symlinks and config entry"; else fail "remove deletes symlinks and config entry" "symlink still exists"; fi
 
+vlog "Removing all remaining stores"
 S removeall >/dev/null 2>&1
 if not_exists "$TARGET_NVIM" && not_exists "$TARGET_SHELLS2/.zshrc"; then
     pass "removeall removes all remaining stores"
@@ -447,6 +500,136 @@ if grep -q "STORE_OS=" "$ENV_LOG" \
     pass "hooks receive platform environment variables"
 else
     fail "hooks receive platform environment variables" "missing env vars"
+fi
+
+# ============================================================
+printf '\n%s\n' "$(bold '=== store adopt (whole directory) ===')"
+# ============================================================
+
+ADOPT_DIR="$TMPDIR_ROOT/adopt-source/myapp"
+mkdir -p "$ADOPT_DIR/sub"
+echo "app config" > "$ADOPT_DIR/app.conf"
+echo "sub config" > "$ADOPT_DIR/sub/nested.conf"
+
+vlog "Dry-run adopting directory $ADOPT_DIR"
+out=$(S adopt "$ADOPT_DIR" --dry-run 2>&1)
+if [[ "$out" == *"myapp"* ]] && [[ "$out" == *"Dry run"* ]]; then
+    pass "adopt --dry-run previews directory adoption"
+else
+    fail "adopt --dry-run previews directory adoption" "got: $out"
+fi
+
+# Verify dry-run didn't move anything.
+if [[ -d "$ADOPT_DIR" ]]; then pass "adopt --dry-run does not move files"; else fail "adopt --dry-run does not move files" "directory was moved"; fi
+
+vlog "Adopting directory $ADOPT_DIR into repo"
+S adopt "$ADOPT_DIR" --force >/dev/null 2>&1
+if [[ -d "$REPO/myapp" ]] && [[ -f "$REPO/myapp/app.conf" ]]; then
+    pass "adopt moves directory into repo"
+else
+    fail "adopt moves directory into repo" "directory not in repo"
+fi
+
+if is_symlink "$ADOPT_DIR"; then
+    pass "adopt creates symlink at original location"
+else
+    fail "adopt creates symlink at original location" "not a symlink"
+fi
+
+if [[ -f "$ADOPT_DIR/app.conf" ]] && [[ -f "$ADOPT_DIR/sub/nested.conf" ]]; then
+    pass "adopted files accessible through symlink"
+else
+    fail "adopted files accessible through symlink" "files not accessible"
+fi
+
+if grep -q "myapp" .store/config.yaml; then
+    pass "adopt writes config entry"
+else
+    fail "adopt writes config entry" "not in config"
+fi
+
+S remove myapp >/dev/null 2>&1
+
+# ============================================================
+printf '\n%s\n' "$(bold '=== store adopt (single file) ===')"
+# ============================================================
+
+ADOPT_FILE="$TMPDIR_ROOT/adopt-source/dotfile/.testrc"
+mkdir -p "$(dirname "$ADOPT_FILE")"
+echo "export TEST=true" > "$ADOPT_FILE"
+
+vlog "Adopting single file $ADOPT_FILE"
+S adopt "$ADOPT_FILE" --force >/dev/null 2>&1
+if [[ -d "$REPO/testrc" ]] && [[ -f "$REPO/testrc/.testrc" ]]; then
+    pass "adopt single file creates store directory with file"
+else
+    fail "adopt single file creates store directory with file" "file not in repo"
+fi
+
+if is_symlink "$ADOPT_FILE"; then
+    pass "adopt single file creates symlink at original location"
+else
+    fail "adopt single file creates symlink at original location" "not a symlink"
+fi
+
+content=$(cat "$ADOPT_FILE")
+if [[ "$content" == "export TEST=true" ]]; then
+    pass "adopted file content preserved through symlink"
+else
+    fail "adopted file content preserved through symlink" "got: $content"
+fi
+
+if grep -q "testrc" .store/config.yaml && grep -q ".testrc" .store/config.yaml; then
+    pass "adopt single file writes config with files list"
+else
+    fail "adopt single file writes config with files list" "config entry wrong"
+fi
+
+S remove testrc >/dev/null 2>&1
+
+# ============================================================
+printf '\n%s\n' "$(bold '=== store adopt (custom name) ===')"
+# ============================================================
+
+ADOPT_CUSTOM="$TMPDIR_ROOT/adopt-source/custom-app"
+mkdir -p "$ADOPT_CUSTOM"
+echo "custom" > "$ADOPT_CUSTOM/config.txt"
+
+vlog "Adopting $ADOPT_CUSTOM with custom name 'myconfig'"
+S adopt "$ADOPT_CUSTOM" --name myconfig --force >/dev/null 2>&1
+if [[ -d "$REPO/myconfig" ]]; then
+    pass "adopt --name overrides derived store name"
+else
+    fail "adopt --name overrides derived store name" "directory not created with custom name"
+fi
+
+if is_symlink "$ADOPT_CUSTOM"; then
+    pass "adopt with custom name creates symlink"
+else
+    fail "adopt with custom name creates symlink" "not a symlink"
+fi
+
+S remove myconfig >/dev/null 2>&1
+
+# ============================================================
+printf '\n%s\n' "$(bold '=== store adopt (error cases) ===')"
+# ============================================================
+
+vlog "Attempting to adopt non-existent path"
+if S adopt "/tmp/nonexistent-path-$$" --force >/dev/null 2>&1; then
+    fail "adopt rejects non-existent path" "should have failed"
+else
+    pass "adopt rejects non-existent path"
+fi
+
+ADOPT_LINK="$TMPDIR_ROOT/adopt-source/link-test"
+mkdir -p "$(dirname "$ADOPT_LINK")"
+ln -s /tmp "$ADOPT_LINK"
+vlog "Attempting to adopt a symlink"
+if S adopt "$ADOPT_LINK" --force >/dev/null 2>&1; then
+    fail "adopt rejects symlinks" "should have failed"
+else
+    pass "adopt rejects symlinks"
 fi
 
 # ============================================================

--- a/test.sh
+++ b/test.sh
@@ -57,6 +57,7 @@ S() {
         local rc=$?
         if [[ -s "$tmpout" ]]; then
             sed 's/^/    /' "$tmpout" >&3
+            printf '\n' >&3
         fi
         # Strip ANSI codes for callers that parse the output.
         sed $'s/\x1b\\[[0-9;]*m//g' "$tmpout"

--- a/test.sh
+++ b/test.sh
@@ -53,12 +53,13 @@ S() {
         printf '\n    %s\n' "$(dim "\$ store $*")" >&3
         local tmpout
         tmpout=$(mktemp)
-        "$STORE_BIN" "$@" > "$tmpout" 2>&1
+        FORCE_COLOR=1 "$STORE_BIN" "$@" > "$tmpout" 2>&1
         local rc=$?
         if [[ -s "$tmpout" ]]; then
             sed 's/^/    /' "$tmpout" >&3
         fi
-        cat "$tmpout"
+        # Strip ANSI codes for callers that parse the output.
+        sed $'s/\x1b\\[[0-9;]*m//g' "$tmpout"
         rm -f "$tmpout"
         return $rc
     else
@@ -478,11 +479,13 @@ printf '\n%s\n' "$(bold '=== store completion ===')"
 # ============================================================
 
 for shell in bash zsh fish powershell; do
-    out=$(S completion "$shell" 2>&1)
+    vlog "Generating $shell completion script"
+    out=$("$STORE_BIN" completion "$shell" 2>&1)
     if [[ -n "$out" ]]; then pass "completion $shell generates output"; else fail "completion $shell generates output" "empty"; fi
 done
 
-if S completion invalid >/dev/null 2>&1; then fail "completion rejects invalid shell" "should have failed"; else pass "completion rejects invalid shell"; fi
+vlog "Attempting completion with invalid shell name"
+if "$STORE_BIN" completion invalid >/dev/null 2>&1; then fail "completion rejects invalid shell" "should have failed"; else pass "completion rejects invalid shell"; fi
 
 # ============================================================
 printf '\n%s\n' "$(bold '=== hook environment variables ===')"


### PR DESCRIPTION
## Summary
- New `store adopt <path>` subcommand that moves an existing file or directory into the repo, creates a config entry, and symlinks back to the original location
- Supports `--name`, `--dry-run`, `--files`, and `--patterns` flags
- Add `FORCE_COLOR` env var support to the UI engine
- Add `-v`/`--verbose` flag to `test.sh` that shows store commands and their colorized output
- Document `store adopt` in README: command reference, comparison table, and quick start

## Test plan
- [x] Acceptance tests for directory adoption, single file adoption, custom name, dry-run, and error cases
- [x] 63/63 acceptance tests pass in both normal and verbose mode
- [x] `go test ./...` passes
- [x] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)