### PR TITLE
Skip template rendering for binary files (fixes #45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `store` are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2026-04-19
+
+### Fixed
+- Skip template rendering for binary files (e.g. images) that coincidentally
+  contain the bytes `{{`. Previously, `store add` would error with
+  `parse template: unrecognized character in action: U+FFFD` when a module
+  contained such a file.
+
 ## [1.3.0] - 2026-04-16
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= v1.3.0
+VERSION ?= v1.3.1
 
 build:
 	go build -ldflags "-X main.version=$(VERSION)" -o store ./cmd/store

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ $ go install github.com/cushycush/store/cmd/store@latest
 ```sh
 $ git clone https://github.com/cushycush/store.git
 $ cd store
-$ make build VERSION=1.3.0
+$ make build VERSION=1.3.1
 $ mv store /usr/local/bin/
 ```
 
@@ -830,7 +830,7 @@ $ store --version
 ```
 
 ```text
-store version 1.3.0
+store version 1.3.1
 ```
 
 If built without an injected version, the binary reports `dev`.

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"strings"
 	"text/template"
+	"unicode/utf8"
 )
 
 // TemplateData provides the dot-accessible fields for templates.
@@ -36,6 +37,16 @@ func HasSecrets(content []byte) bool {
 // HasTemplates checks if file content contains any {{ ... }} template syntax.
 func HasTemplates(content []byte) bool {
 	return templatePattern.Match(content)
+}
+
+// IsBinary reports whether content looks like binary data unsuitable for
+// template rendering. Go's text/template requires valid UTF-8 input and
+// binary files that happen to contain the bytes `{{` will crash the parser.
+func IsBinary(content []byte) bool {
+	if bytes.IndexByte(content, 0) >= 0 {
+		return true
+	}
+	return !utf8.Valid(content)
 }
 
 // Render replaces all template expressions in content. Supports:
@@ -140,7 +151,7 @@ func NeedsTemplateRendering(dir string) (bool, error) {
 		if err != nil {
 			return err
 		}
-		if HasTemplates(content) {
+		if !IsBinary(content) && HasTemplates(content) {
 			return errTemplatesFound
 		}
 
@@ -213,7 +224,7 @@ func PrepareStaging(sourceDir, stagingDir string, secrets map[string]string, dat
 			return fmt.Errorf("read %s: %w", path, err)
 		}
 
-		if HasTemplates(content) {
+		if !IsBinary(content) && HasTemplates(content) {
 			rendered, err := Render(content, secrets, data)
 			if err != nil {
 				return fmt.Errorf("render %s: %w", path, err)

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -122,7 +122,7 @@ func NeedsRendering(dir string) (bool, error) {
 		if err != nil {
 			return err
 		}
-		if HasSecrets(content) {
+		if !IsBinary(content) && HasSecrets(content) {
 			return errTemplatesFound
 		}
 

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -35,6 +35,30 @@ func TestHasSecrets(t *testing.T) {
 	}
 }
 
+func TestIsBinary(t *testing.T) {
+	tests := []struct {
+		name    string
+		content []byte
+		want    bool
+	}{
+		{name: "plain text", content: []byte("hello world"), want: false},
+		{name: "utf-8 text", content: []byte("héllo 世界"), want: false},
+		{name: "template syntax", content: []byte(`{{ secret "x" }}`), want: false},
+		{name: "contains NUL byte", content: []byte("abc\x00def"), want: true},
+		{name: "PNG-like header", content: []byte("\x89PNG\r\n\x1a\n{{IHDR"), want: true},
+		{name: "invalid utf-8", content: []byte{0xff, 0xfe, 0xfd}, want: true},
+		{name: "empty content", content: []byte{}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsBinary(tt.content); got != tt.want {
+				t.Fatalf("IsBinary() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRender(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -146,6 +170,13 @@ func TestNeedsRendering(t *testing.T) {
 				writeTestFile(t, filepath.Join(dir, "nested", "deep", "secret.txt"), `{{secret "nested"}}`)
 			},
 			want: true,
+		},
+		{
+			name: "ignores binary files that contain template bytes",
+			setup: func(t *testing.T, dir string) {
+				writeTestFile(t, filepath.Join(dir, "image.png"), "\x89PNG\r\n\x1a\n{{ secret \"x\" }}")
+			},
+			want: false,
 		},
 		{
 			name: "skips directories themselves",
@@ -341,6 +372,17 @@ func TestPrepareStaging(t *testing.T) {
 			},
 			secrets: map[string]string{},
 			wantErr: `missing secret: missing`,
+		},
+		{
+			name: "binary files with template-looking bytes are symlinked, not rendered",
+			setup: func(t *testing.T, sourceDir, stagingDir string) {
+				writeTestFile(t, filepath.Join(sourceDir, "image.png"), "\x89PNG\r\n\x1a\n{{IHDR\x00payload")
+			},
+			secrets: map[string]string{},
+			want:    false,
+			assertion: func(t *testing.T, sourceDir, stagingDir string) {
+				assertSymlinkTarget(t, filepath.Join(stagingDir, "image.png"), filepath.Join(sourceDir, "image.png"))
+			},
 		},
 		{
 			name:    "empty directory returns false",


### PR DESCRIPTION
## Summary
- Binary files (e.g. PNGs) can coincidentally contain the bytes `{{`, which caused `text/template` to try parsing them and fail with `unrecognized character in action: U+FFFD`.
- Added `IsBinary` (NUL byte or invalid UTF-8) and gated template detection on it in `PrepareStaging`, `NeedsTemplateRendering`, and `NeedsRendering`. Binary files now pass through as symlinks instead of being rendered.

Fixes #45.

## Test plan
- [x] `go test ./...` passes
- [x] New unit tests for `IsBinary`, the symlink path through `PrepareStaging` for binaries, and `NeedsRendering`'s binary skip
- [x] Reproduce reporter's scenario: `store init` → drop a PNG into a module dir → `store add` no longer errors