### PR TITLE
Feature/cli remove normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -701,29 +701,29 @@ How it works:
 - Removes old symlinks for the selected target first.
 - Re-links only the updated target after saving config.
 
-### `store remove <name>`
+### `store remove [name]`
 
-Removes the store's symlinked targets and deletes the store entry from config.
+Removes the store's symlinked targets and deletes the store entry from config. With `--all`, removes every configured store.
+
+| Flag     | Description                                                       |
+| -------- | ----------------------------------------------------------------- |
+| `--all`  | Remove every configured store                                     |
+| `--yes`  | Skip the confirmation prompt when using `--all`                   |
 
 ```sh
 $ store remove nvim
+$ store remove --all
+$ store remove --all --yes
 ```
 
 ```text
+$ store remove nvim
 Removed store nvim (~/.config/nvim)
 ```
 
-The directory inside your repo is left untouched.
-
-### `store removeall`
-
-Removes all configured store symlinks and deletes their config entries.
-
-```sh
-$ store removeall
-```
-
 ```text
+$ store remove --all
+Remove ALL configured stores? [y/N] y
 Removing all stores:
   removed nvim (~/.config/nvim)
   removed git (~/.config/git)
@@ -731,8 +731,9 @@ Removing all stores:
 
 How it works:
 
-- Runs global `pre-remove` and `post-remove` hooks if present.
-- Continues removing other stores even if one store fails, then reports aggregated errors.
+- With a name, removes that one store's symlinks and config entry. The directory inside your repo is left untouched.
+- With `--all`, prompts for y/N unless `--yes` is passed, then runs global `pre-remove` and `post-remove` hooks and removes every store. Continues removing other stores even if one fails, then reports aggregated errors.
+- `store removeall` is a deprecated alias for `store remove --all --yes` and prints a deprecation warning. Use the new form.
 
 ### `store status [name]`
 
@@ -857,11 +858,12 @@ Prints one decrypted secret value.
 $ store secret get github_token
 ```
 
-### `store secret rm <name>`
+### `store secret remove <name>`
 
-Deletes one secret from `.store/secrets.enc`.
+Deletes one secret from `.store/secrets.enc`. Aliased as `store secret rm`.
 
 ```sh
+$ store secret remove github_token
 $ store secret rm github_token
 ```
 

--- a/cmd/store/commands.go
+++ b/cmd/store/commands.go
@@ -338,10 +338,11 @@ func newSecretCmd() *cobra.Command {
 			RunE:  runSecretGet,
 		},
 		&cobra.Command{
-			Use:   "rm <name>",
-			Short: "Remove a secret",
-			Args:  cobra.ExactArgs(1),
-			RunE:  runSecretRemove,
+			Use:     "remove <name>",
+			Aliases: []string{"rm"},
+			Short:   "Remove a secret",
+			Args:    cobra.ExactArgs(1),
+			RunE:    runSecretRemove,
 		},
 		&cobra.Command{
 			Use:   "list",

--- a/cmd/store/commands.go
+++ b/cmd/store/commands.go
@@ -194,10 +194,12 @@ confirmation unless --yes is passed.`,
 
 func newRemoveAllCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "removeall",
-		Short: "Remove all store symlinks",
-		Long:  "Removes symlinks and config entries for all stores defined in the config.",
-		RunE:  runRemoveAll,
+		Use:        "removeall",
+		Short:      "Remove all store symlinks",
+		Long:       "Removes symlinks and config entries for all stores defined in the config.",
+		Deprecated: "use `store remove --all` instead.",
+		Hidden:     true,
+		RunE:       runRemoveAll,
 	}
 }
 

--- a/cmd/store/commands.go
+++ b/cmd/store/commands.go
@@ -158,13 +158,36 @@ The old symlinks are removed before applying changes.`,
 }
 
 func newRemoveCmd() *cobra.Command {
+	var all bool
+	var yes bool
+
 	cmd := &cobra.Command{
 		Use:   "remove <name>",
 		Short: "Remove a store's symlink",
-		Long:  "Removes the symlink for the named store and deletes its config entry.",
-		Args:  cobra.ExactArgs(1),
-		RunE:  runRemove,
+		Long: `Removes the symlink for the named store and deletes its config entry.
+
+Use --all to remove every configured store at once. --all prompts for
+confirmation unless --yes is passed.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if all {
+				if len(args) > 0 {
+					return fmt.Errorf("--all does not accept a store name")
+				}
+				if !yes && !promptYesNo("Remove ALL configured stores?") {
+					cmd.SilenceUsage = true
+					return fmt.Errorf("aborted")
+				}
+				return runRemoveAll(cmd, args)
+			}
+			if len(args) == 0 {
+				return fmt.Errorf("specify a store name or use --all")
+			}
+			return runRemove(cmd, args)
+		},
 	}
+	cmd.Flags().BoolVar(&all, "all", false, "remove every configured store")
+	cmd.Flags().BoolVar(&yes, "yes", false, "skip confirmation prompt when using --all")
 	cmd.ValidArgsFunction = completeStoreNames
 	return cmd
 }

--- a/test.sh
+++ b/test.sh
@@ -241,7 +241,7 @@ S target remove shells -t "$TARGET_NU" >/dev/null 2>&1
 if not_exists "$TARGET_NU/config.nu"; then pass "target remove unlinks and removes target"; else fail "target remove unlinks and removes target" "symlink still exists"; fi
 
 # ============================================================
-printf '\n%s\n' "$(bold '=== store remove / removeall ===')"
+printf '\n%s\n' "$(bold '=== store remove ===')"
 # ============================================================
 
 vlog "Removing configs store"
@@ -249,11 +249,11 @@ S remove configs >/dev/null 2>&1
 if not_exists "$TARGET_CONFIGS/app.conf"; then pass "remove deletes symlinks and config entry"; else fail "remove deletes symlinks and config entry" "symlink still exists"; fi
 
 vlog "Removing all remaining stores"
-S removeall >/dev/null 2>&1
+S remove --all --yes >/dev/null 2>&1
 if not_exists "$TARGET_NVIM" && not_exists "$TARGET_SHELLS2/.zshrc"; then
-    pass "removeall removes all remaining stores"
+    pass "remove --all removes all remaining stores"
 else
-    fail "removeall removes all remaining stores" "some symlinks remain"
+    fail "remove --all removes all remaining stores" "some symlinks remain"
 fi
 
 # ============================================================
@@ -305,9 +305,9 @@ else
     fail "secret set second secret" "got: $out"
 fi
 
-S secret rm api_key >/dev/null 2>&1
+S secret remove api_key >/dev/null 2>&1
 out=$(S secret list 2>&1)
-if [[ "$out" != *"api_key"* ]]; then pass "secret rm removes a secret"; else fail "secret rm removes a secret" "api_key still present"; fi
+if [[ "$out" != *"api_key"* ]]; then pass "secret remove removes a secret"; else fail "secret remove removes a secret" "api_key still present"; fi
 
 # ============================================================
 printf '\n%s\n' "$(bold '=== secret template rendering ===')"


### PR DESCRIPTION
# Normalize remove verbs: `store remove --all` and `secret remove` alias

## Summary

Before this PR, the CLI mixed three patterns for the same semantic: `store remove <name>` at the top level, `store removeall` as a peer bulk command, and `store secret rm <name>` under `secret`. That's three conventions for one concept — and `removeall` was a single keystroke away from `remove` with no confirmation.

This PR normalizes on `remove` everywhere, folds the bulk operation into `store remove --all`, and adds a confirmation prompt for the destructive bulk path.

## Changes

- **New:** `store remove --all` — removes every configured store. Prompts y/N unless `--yes` is passed.
- **Renamed:** `store secret rm` → `store secret remove`. `rm` is kept as an alias so existing usage keeps working.
- **Deprecated:** `store removeall` is now hidden from help and prints a deprecation warning pointing at `store remove --all`. The command still runs for now.
- **Updated:** Acceptance tests use `store remove --all --yes` and `store secret remove`.
- **Updated:** README documents the new flags and the rename.

## Breaking changes

None today — deprecated paths continue to work. Plan to remove `store removeall` in a future release.

## Test plan

- [x] `go test ./...` — green
- [x] `bash test.sh` — 63/63 acceptance tests pass
- [x] `store remove <name>` works as before
- [x] `store remove --all` prompts and honors y/N
- [x] `store remove --all --yes` skips the prompt
- [x] `store removeall` still works but prints a deprecation warning
- [x] `store secret remove <name>` works
- [x] `store secret rm <name>` still works via alias
