### PR TITLE
Feature/cli modify additive

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,24 +616,31 @@ How it works:
 
 ### `store modify <name>`
 
-Updates an existing single-target store. Each provided flag replaces the entire field.
+Updates an existing single-target store. Choose between wholesale replacement, incremental changes, or both.
 
-| Flag               | Short | Description                          |
-| ------------------ | ----- | ------------------------------------ |
-| `--target`         | `-t`  | Replace the target path              |
-| `--files`          | `-f`  | Replace the file list; repeatable    |
-| `--patterns`       | `-p`  | Replace the pattern list; repeatable |
-| `--clear-files`    |       | Remove all files from the entry      |
-| `--clear-patterns` |       | Remove all patterns from the entry   |
+| Flag               | Short | Description                                                |
+| ------------------ | ----- | ---------------------------------------------------------- |
+| `--target`         | `-t`  | Replace the target path                                    |
+| `--files`          | `-f`  | Replace the file list; repeatable                          |
+| `--patterns`       | `-p`  | Replace the pattern list; repeatable                       |
+| `--add-file`       |       | Append a file to the file list; repeatable                 |
+| `--remove-file`    |       | Remove a file from the file list; repeatable               |
+| `--add-pattern`    |       | Append a pattern to the pattern list; repeatable           |
+| `--remove-pattern` |       | Remove a pattern from the pattern list; repeatable         |
+| `--clear-files`    |       | Remove all files from the entry                            |
+| `--clear-patterns` |       | Remove all patterns from the entry                         |
 
 ```sh
 $ store modify nvim -t ~/.config/nvim-custom
 $ store modify shells --clear-files -p ".zsh*" -p ".bash*"
+$ store modify shells --add-file .zprofile
+$ store modify shells --remove-file .bashrc
 ```
 
 How it works:
 
 - Removes old symlinks before applying the updated config.
+- Flags compose in this order: `--clear-*` → `--files`/`--patterns` → `--add-*` → `--remove-*`. This lets `--add-file` append to the existing list without replacing it, or to a replacement list supplied by `--files`.
 - Re-links the store after saving the new entry.
 - Refuses to run on multi-target stores; use `store target modify` instead.
 
@@ -681,24 +688,30 @@ How it works:
 
 ### `store target modify <name>`
 
-Updates the `files` or `patterns` for one target inside a multi-target store.
+Updates the `files` or `patterns` for one target inside a multi-target store. Supports the same wholesale and incremental flags as `store modify`.
 
-| Flag               | Short | Description                          |
-| ------------------ | ----- | ------------------------------------ |
-| `--target`         | `-t`  | Target path to modify; required      |
-| `--files`          | `-f`  | Replace the file list; repeatable    |
-| `--patterns`       | `-p`  | Replace the pattern list; repeatable |
-| `--clear-files`    |       | Remove all files from the target     |
-| `--clear-patterns` |       | Remove all patterns from the target  |
+| Flag               | Short | Description                                                |
+| ------------------ | ----- | ---------------------------------------------------------- |
+| `--target`         | `-t`  | Target path to modify; required                            |
+| `--files`          | `-f`  | Replace the file list; repeatable                          |
+| `--patterns`       | `-p`  | Replace the pattern list; repeatable                       |
+| `--add-file`       |       | Append a file to the file list; repeatable                 |
+| `--remove-file`    |       | Remove a file from the file list; repeatable               |
+| `--add-pattern`    |       | Append a pattern to the pattern list; repeatable           |
+| `--remove-pattern` |       | Remove a pattern from the pattern list; repeatable         |
+| `--clear-files`    |       | Remove all files from the target                           |
+| `--clear-patterns` |       | Remove all patterns from the target                        |
 
 ```sh
 $ store target modify shells -t ~ -f .zshrc -f .bashrc -f .zprofile
+$ store target modify shells -t ~ --add-file .zprofile
 $ store target modify shells -t ~/.config/nushell --clear-files -p "*.nu"
 ```
 
 How it works:
 
 - Removes old symlinks for the selected target first.
+- Flag composition is the same as `store modify`: `--clear-*` → replace → add → remove.
 - Re-links only the updated target after saving config.
 
 ### `store remove <name>`

--- a/cmd/store/commands.go
+++ b/cmd/store/commands.go
@@ -302,16 +302,21 @@ func newTargetModifyCmd() *cobra.Command {
 	var patterns []string
 	var clearFiles bool
 	var clearPatterns bool
+	var ops modifyOps
 
 	cmd := &cobra.Command{
 		Use:   "modify <name>",
 		Short: "Modify a target within a store",
 		Long: `Modifies the files or patterns for a specific target within a store.
-The target is identified by its path (-t flag). Each provided flag replaces
-the entire field. Use --clear-files or --clear-patterns to remove those fields.`,
+The target is identified by its path (-t flag).
+
+--files and --patterns replace the entire list for that target. --add-file,
+--remove-file, --add-pattern, --remove-pattern apply incremental changes.
+--clear-files and --clear-patterns empty the list entirely. Flags compose
+as clear → replace → add → remove.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runTargetModify(cmd, args[0], target, files, patterns, clearFiles, clearPatterns)
+			return runTargetModify(cmd, args[0], target, files, patterns, clearFiles, clearPatterns, ops)
 		},
 	}
 
@@ -319,6 +324,10 @@ the entire field. Use --clear-files or --clear-patterns to remove those fields.`
 	mustMarkFlagRequired(cmd, "target")
 	cmd.Flags().StringArrayVarP(&files, "files", "f", nil, "replace file list (repeatable)")
 	cmd.Flags().StringArrayVarP(&patterns, "patterns", "p", nil, "replace pattern list (repeatable)")
+	cmd.Flags().StringArrayVar(&ops.addFiles, "add-file", nil, "append a file to the file list (repeatable)")
+	cmd.Flags().StringArrayVar(&ops.removeFiles, "remove-file", nil, "remove a file from the file list (repeatable)")
+	cmd.Flags().StringArrayVar(&ops.addPatterns, "add-pattern", nil, "append a pattern to the pattern list (repeatable)")
+	cmd.Flags().StringArrayVar(&ops.removePatterns, "remove-pattern", nil, "remove a pattern from the pattern list (repeatable)")
 	cmd.Flags().BoolVar(&clearFiles, "clear-files", false, "remove all files from the target")
 	cmd.Flags().BoolVar(&clearPatterns, "clear-patterns", false, "remove all patterns from the target")
 	cmd.ValidArgsFunction = completeStoreNames

--- a/cmd/store/commands.go
+++ b/cmd/store/commands.go
@@ -133,23 +133,32 @@ func newModifyCmd() *cobra.Command {
 	var patterns []string
 	var clearFiles bool
 	var clearPatterns bool
+	var ops modifyOps
 
 	cmd := &cobra.Command{
 		Use:   "modify <name>",
 		Short: "Modify an existing store entry",
-		Long: `Updates fields on an existing store entry. Each provided flag replaces
-the entire field. Use --clear-files or --clear-patterns to remove those fields.
+		Long: `Updates fields on an existing store entry.
+
+--files and --patterns replace the entire list. --add-file, --remove-file,
+--add-pattern, --remove-pattern apply incremental changes without touching
+other entries. --clear-files and --clear-patterns empty the list entirely.
+Flags compose in this order: clear, replace, add, remove.
 
 The old symlinks are removed before applying changes.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runModify(cmd, args[0], target, files, patterns, clearFiles, clearPatterns)
+			return runModify(cmd, args[0], target, files, patterns, clearFiles, clearPatterns, ops)
 		},
 	}
 
 	cmd.Flags().StringVarP(&target, "target", "t", "", "new target path")
 	cmd.Flags().StringArrayVarP(&files, "files", "f", nil, "replace file list (repeatable)")
 	cmd.Flags().StringArrayVarP(&patterns, "patterns", "p", nil, "replace pattern list (repeatable)")
+	cmd.Flags().StringArrayVar(&ops.addFiles, "add-file", nil, "append a file to the file list (repeatable)")
+	cmd.Flags().StringArrayVar(&ops.removeFiles, "remove-file", nil, "remove a file from the file list (repeatable)")
+	cmd.Flags().StringArrayVar(&ops.addPatterns, "add-pattern", nil, "append a pattern to the pattern list (repeatable)")
+	cmd.Flags().StringArrayVar(&ops.removePatterns, "remove-pattern", nil, "remove a pattern from the pattern list (repeatable)")
 	cmd.Flags().BoolVar(&clearFiles, "clear-files", false, "remove all files from the entry")
 	cmd.Flags().BoolVar(&clearPatterns, "clear-patterns", false, "remove all patterns from the entry")
 	cmd.ValidArgsFunction = completeStoreNames

--- a/cmd/store/helpers.go
+++ b/cmd/store/helpers.go
@@ -20,6 +20,40 @@ import (
 	"golang.org/x/term"
 )
 
+// applyListOps returns list with add entries appended (deduplicated) and
+// remove entries filtered out. Used by modify/target modify to implement
+// --add-file / --remove-file and --add-pattern / --remove-pattern.
+func applyListOps(list, add, remove []string) []string {
+	seen := make(map[string]bool, len(list))
+	result := make([]string, 0, len(list)+len(add))
+	for _, v := range list {
+		if !seen[v] {
+			result = append(result, v)
+			seen[v] = true
+		}
+	}
+	for _, v := range add {
+		if !seen[v] {
+			result = append(result, v)
+			seen[v] = true
+		}
+	}
+	if len(remove) == 0 {
+		return result
+	}
+	rem := make(map[string]bool, len(remove))
+	for _, v := range remove {
+		rem[v] = true
+	}
+	filtered := result[:0]
+	for _, v := range result {
+		if !rem[v] {
+			filtered = append(filtered, v)
+		}
+	}
+	return filtered
+}
+
 func findRootAndConfig() (string, *config.Config, error) {
 	root, err := config.FindRoot()
 	if err != nil {

--- a/cmd/store/store_ops.go
+++ b/cmd/store/store_ops.go
@@ -69,7 +69,14 @@ func runAdd(name, target string, files, patterns []string) error {
 	return nil
 }
 
-func runModify(cmd *cobra.Command, name, target string, files, patterns []string, clearFiles, clearPatterns bool) error {
+type modifyOps struct {
+	addFiles      []string
+	removeFiles   []string
+	addPatterns   []string
+	removePatterns []string
+}
+
+func runModify(cmd *cobra.Command, name, target string, files, patterns []string, clearFiles, clearPatterns bool, ops modifyOps) error {
 	root, cfg, err := findRootAndConfig()
 	if err != nil {
 		return err
@@ -96,18 +103,20 @@ func runModify(cmd *cobra.Command, name, target string, files, patterns []string
 		}
 		entry.Target = target
 	}
+	if clearFiles {
+		entry.Files = nil
+	}
 	if cmd.Flags().Changed("files") {
 		entry.Files = files
 	}
-	if clearFiles {
-		entry.Files = nil
+	entry.Files = applyListOps(entry.Files, ops.addFiles, ops.removeFiles)
+	if clearPatterns {
+		entry.Patterns = nil
 	}
 	if cmd.Flags().Changed("patterns") {
 		entry.Patterns = patterns
 	}
-	if clearPatterns {
-		entry.Patterns = nil
-	}
+	entry.Patterns = applyListOps(entry.Patterns, ops.addPatterns, ops.removePatterns)
 
 	cfg.Stores[name] = entry
 	if err := config.Save(root, cfg); err != nil {

--- a/cmd/store/store_ops.go
+++ b/cmd/store/store_ops.go
@@ -413,7 +413,7 @@ func runTargetRemove(name, target string) error {
 	return nil
 }
 
-func runTargetModify(cmd *cobra.Command, name, target string, files, patterns []string, clearFiles, clearPatterns bool) error {
+func runTargetModify(cmd *cobra.Command, name, target string, files, patterns []string, clearFiles, clearPatterns bool, ops modifyOps) error {
 	root, cfg, err := findRootAndConfig()
 	if err != nil {
 		return err
@@ -451,18 +451,20 @@ func runTargetModify(cmd *cobra.Command, name, target string, files, patterns []
 	}
 
 	targetEntry := &entry.Targets[found]
+	if clearFiles {
+		targetEntry.Files = nil
+	}
 	if cmd.Flags().Changed("files") {
 		targetEntry.Files = files
 	}
-	if clearFiles {
-		targetEntry.Files = nil
+	targetEntry.Files = applyListOps(targetEntry.Files, ops.addFiles, ops.removeFiles)
+	if clearPatterns {
+		targetEntry.Patterns = nil
 	}
 	if cmd.Flags().Changed("patterns") {
 		targetEntry.Patterns = patterns
 	}
-	if clearPatterns {
-		targetEntry.Patterns = nil
-	}
+	targetEntry.Patterns = applyListOps(targetEntry.Patterns, ops.addPatterns, ops.removePatterns)
 
 	entry.MigrateToSingleTarget()
 

--- a/test.sh
+++ b/test.sh
@@ -215,6 +215,22 @@ if is_symlink "$TARGET_SHELLS2/.zshrc"; then pass "modify changes target and rel
 
 if not_exists "$TARGET_SHELLS/.zshrc"; then pass "old target symlinks removed after modify"; else fail "old target symlinks removed after modify" "old symlink still exists"; fi
 
+vlog "Modify --add-file appends .bashrc without touching .zshrc"
+S modify shells --add-file .bashrc >/dev/null 2>&1
+if is_symlink "$TARGET_SHELLS2/.zshrc" && is_symlink "$TARGET_SHELLS2/.bashrc"; then
+    pass "modify --add-file appends without replacing"
+else
+    fail "modify --add-file appends without replacing" "expected both .zshrc and .bashrc to be linked"
+fi
+
+vlog "Modify --remove-file drops .bashrc, keeps .zshrc"
+S modify shells --remove-file .bashrc >/dev/null 2>&1
+if is_symlink "$TARGET_SHELLS2/.zshrc" && not_exists "$TARGET_SHELLS2/.bashrc"; then
+    pass "modify --remove-file removes single entry"
+else
+    fail "modify --remove-file removes single entry" ".bashrc still linked or .zshrc missing"
+fi
+
 # ============================================================
 printf '\n%s\n' "$(bold '=== store target add / remove / modify ===')"
 # ============================================================


### PR DESCRIPTION
# Add additive modify flags: `--add-file`, `--remove-file`, `--add-pattern`, `--remove-pattern`

## Summary

Before this PR, `store modify shells -f .zshrc` silently *replaced* the entire `files` list with just `.zshrc`, wiping out `.bashrc`, `.zprofile`, and anything else. The existence of `--clear-files` was itself evidence that the replace-by-default semantic was surprising enough to need an escape hatch. Users reaching for `-f` naturally expect it to *append*.

This PR keeps the existing wholesale semantic for backwards compatibility and adds a full set of additive operations so users can make incremental edits without reconstructing the entire list.

## Changes

- **New on `store modify`:**
  - `--add-file` — append a file to the list (repeatable)
  - `--remove-file` — remove a specific file from the list (repeatable)
  - `--add-pattern` — append a pattern (repeatable)
  - `--remove-pattern` — remove a pattern (repeatable)
- **Same flags mirrored on `store target modify`** for multi-target stores.
- **Composition order documented:** `--clear-*` → `--files`/`--patterns` → `--add-*` → `--remove-*`. You can combine them; `-f .zshrc --add-file .bashrc` first replaces with `[.zshrc]` then appends `.bashrc`.
- **Unchanged:** `-f`/`--files` and `-p`/`--patterns` retain their replace-the-entire-list semantic.
- **Added** `applyListOps` helper for the dedupe + remove logic used by both command paths.

## Breaking changes

None. Existing `-f` / `-p` / `--clear-*` behavior is preserved.

## Test plan

- [x] `go test ./...` — green
- [x] `bash test.sh` — 65/65 acceptance tests pass (2 new cases)
- [x] `store modify shells --add-file .bashrc` appends without touching existing entries
- [x] `store modify shells --remove-file .bashrc` drops one entry, keeps the rest
- [x] `store target modify shells -t ~ --add-file .zprofile` works on multi-target stores
- [x] `-f .zshrc --add-file .bashrc` composes: replace then append
