### PR TITLE
Feature/cli target positional

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,18 +646,18 @@ How it works:
 - Re-links the store after saving the new entry.
 - Refuses to run on multi-target stores; use `store target modify` instead.
 
-### `store target add <name>`
+### `store target add <name> [target]`
 
-Adds another target to an existing store.
+Adds another target to an existing store. The target path may be passed positionally or via `-t`/`--target`.
 
 | Flag         | Short | Description                                             |
 | ------------ | ----- | ------------------------------------------------------- |
-| `--target`   | `-t`  | Target path to add; required                            |
+| `--target`   | `-t`  | Target path (or pass positionally)                      |
 | `--files`    | `-f`  | Explicit files to link individually; repeatable         |
 | `--patterns` | `-p`  | Glob patterns to match files; repeatable; supports `**` |
 
 ```sh
-$ store target add shells -t ~/.config/fish -f config.fish
+$ store target add shells ~/.config/fish -f config.fish
 $ store target add shells -t ~/.config/nushell -p "*.nu"
 ```
 
@@ -665,17 +665,18 @@ How it works:
 
 - Automatically migrates a single-target store to the `targets:` format.
 - Rejects duplicate target paths after normalizing `~` and absolute paths.
+- Passing both a positional target and `--target` is an error; pick one.
 
-### `store target remove <name>`
+### `store target remove <name> [target]`
 
 Removes one target from a store and unlinks that target's symlinks.
 
-| Flag       | Short | Description                     |
-| ---------- | ----- | ------------------------------- |
-| `--target` | `-t`  | Target path to remove; required |
+| Flag       | Short | Description                        |
+| ---------- | ----- | ---------------------------------- |
+| `--target` | `-t`  | Target path (or pass positionally) |
 
 ```sh
-$ store target remove shells -t ~/.config/fish
+$ store target remove shells ~/.config/fish
 ```
 
 ```text
@@ -688,13 +689,13 @@ How it works:
 - Unlinks that target.
 - Migrates the store back to single-target format automatically if one target remains.
 
-### `store target modify <name>`
+### `store target modify <name> [target]`
 
 Updates the `files` or `patterns` for one target inside a multi-target store. Supports the same wholesale and incremental flags as `store modify`.
 
 | Flag               | Short | Description                                                |
 | ------------------ | ----- | ---------------------------------------------------------- |
-| `--target`         | `-t`  | Target path to modify; required                            |
+| `--target`         | `-t`  | Target path (or pass positionally)                         |
 | `--files`          | `-f`  | Replace the file list; repeatable                          |
 | `--patterns`       | `-p`  | Replace the pattern list; repeatable                       |
 | `--add-file`       |       | Append a file to the file list; repeatable                 |
@@ -705,9 +706,9 @@ Updates the `files` or `patterns` for one target inside a multi-target store. Su
 | `--clear-patterns` |       | Remove all patterns from the target                        |
 
 ```sh
-$ store target modify shells -t ~ -f .zshrc -f .bashrc -f .zprofile
-$ store target modify shells -t ~ --add-file .zprofile
-$ store target modify shells -t ~/.config/nushell --clear-files -p "*.nu"
+$ store target modify shells ~ -f .zshrc -f .bashrc -f .zprofile
+$ store target modify shells ~ --add-file .zprofile
+$ store target modify shells ~/.config/nushell --clear-files -p "*.nu"
 ```
 
 How it works:

--- a/cmd/store/commands.go
+++ b/cmd/store/commands.go
@@ -297,18 +297,23 @@ func newTargetAddCmd() *cobra.Command {
 	var patterns []string
 
 	cmd := &cobra.Command{
-		Use:   "add <name>",
+		Use:   "add <name> [target]",
 		Short: "Add a target to a store",
 		Long: `Adds a new target entry to an existing store. If the store currently uses
-the single-target format, it is automatically migrated to the multi-target format.`,
-		Args: cobra.ExactArgs(1),
+the single-target format, it is automatically migrated to the multi-target format.
+
+The target path may be passed positionally or with -t/--target.`,
+		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runTargetAdd(args[0], target, files, patterns)
+			resolved, err := resolvePositionalTarget(cmd, args, target)
+			if err != nil {
+				return err
+			}
+			return runTargetAdd(args[0], resolved, files, patterns)
 		},
 	}
 
-	cmd.Flags().StringVarP(&target, "target", "t", "", "target path for the symlink (required)")
-	mustMarkFlagRequired(cmd, "target")
+	cmd.Flags().StringVarP(&target, "target", "t", "", "target path for the symlink (or pass positionally)")
 	cmd.Flags().StringArrayVarP(&files, "files", "f", nil, "explicit files to symlink (repeatable)")
 	cmd.Flags().StringArrayVarP(&patterns, "patterns", "p", nil, "glob patterns to match files (repeatable, supports **)")
 	cmd.ValidArgsFunction = completeStoreNames
@@ -320,17 +325,22 @@ func newTargetRemoveCmd() *cobra.Command {
 	var target string
 
 	cmd := &cobra.Command{
-		Use:   "remove <name>",
+		Use:   "remove <name> [target]",
 		Short: "Remove a target from a store",
-		Long:  "Removes a specific target (by path) from a store and unlinks its symlinks.",
-		Args:  cobra.ExactArgs(1),
+		Long: `Removes a specific target (by path) from a store and unlinks its symlinks.
+
+The target path may be passed positionally or with -t/--target.`,
+		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runTargetRemove(args[0], target)
+			resolved, err := resolvePositionalTarget(cmd, args, target)
+			if err != nil {
+				return err
+			}
+			return runTargetRemove(args[0], resolved)
 		},
 	}
 
-	cmd.Flags().StringVarP(&target, "target", "t", "", "target path to remove (required)")
-	mustMarkFlagRequired(cmd, "target")
+	cmd.Flags().StringVarP(&target, "target", "t", "", "target path to remove (or pass positionally)")
 	cmd.ValidArgsFunction = completeStoreNames
 
 	return cmd
@@ -345,23 +355,26 @@ func newTargetModifyCmd() *cobra.Command {
 	var ops modifyOps
 
 	cmd := &cobra.Command{
-		Use:   "modify <name>",
+		Use:   "modify <name> [target]",
 		Short: "Modify a target within a store",
 		Long: `Modifies the files or patterns for a specific target within a store.
-The target is identified by its path (-t flag).
+The target path may be passed positionally or with -t/--target.
 
 --files and --patterns replace the entire list for that target. --add-file,
 --remove-file, --add-pattern, --remove-pattern apply incremental changes.
 --clear-files and --clear-patterns empty the list entirely. Flags compose
 as clear → replace → add → remove.`,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runTargetModify(cmd, args[0], target, files, patterns, clearFiles, clearPatterns, ops)
+			resolved, err := resolvePositionalTarget(cmd, args, target)
+			if err != nil {
+				return err
+			}
+			return runTargetModify(cmd, args[0], resolved, files, patterns, clearFiles, clearPatterns, ops)
 		},
 	}
 
-	cmd.Flags().StringVarP(&target, "target", "t", "", "target path to modify (required)")
-	mustMarkFlagRequired(cmd, "target")
+	cmd.Flags().StringVarP(&target, "target", "t", "", "target path to modify (or pass positionally)")
 	cmd.Flags().StringArrayVarP(&files, "files", "f", nil, "replace file list (repeatable)")
 	cmd.Flags().StringArrayVarP(&patterns, "patterns", "p", nil, "replace pattern list (repeatable)")
 	cmd.Flags().StringArrayVar(&ops.addFiles, "add-file", nil, "append a file to the file list (repeatable)")

--- a/cmd/store/helpers.go
+++ b/cmd/store/helpers.go
@@ -54,6 +54,25 @@ func applyListOps(list, add, remove []string) []string {
 	return filtered
 }
 
+// resolvePositionalTarget returns the target path from args[1] or --target,
+// erroring if both or neither are supplied. Used by target add/remove/modify.
+func resolvePositionalTarget(cmd *cobra.Command, args []string, flagValue string) (string, error) {
+	positional := ""
+	if len(args) >= 2 {
+		positional = args[1]
+	}
+	if positional != "" && cmd.Flags().Changed("target") {
+		return "", fmt.Errorf("target given both as positional argument and via --target; pick one")
+	}
+	if positional != "" {
+		return positional, nil
+	}
+	if flagValue == "" {
+		return "", fmt.Errorf("target required (positional argument or --target flag)")
+	}
+	return flagValue, nil
+}
+
 func findRootAndConfig() (string, *config.Config, error) {
 	root, err := config.FindRoot()
 	if err != nil {

--- a/test.sh
+++ b/test.sh
@@ -240,21 +240,21 @@ TARGET_NU="$TMPDIR_ROOT/targets/nu"
 mkdir -p "$TARGET_FISH" "$TARGET_NU"
 echo 'set nu' > "$REPO/shells/config.nu"
 
-vlog "Adding fish target to shells store"
-S target add shells -t "$TARGET_FISH" -f config.fish >/dev/null 2>&1
-if is_symlink "$TARGET_FISH/config.fish"; then pass "target add creates multi-target store"; else fail "target add creates multi-target store" "not linked"; fi
+vlog "Adding fish target to shells store (positional form)"
+S target add shells "$TARGET_FISH" -f config.fish >/dev/null 2>&1
+if is_symlink "$TARGET_FISH/config.fish"; then pass "target add accepts positional target"; else fail "target add accepts positional target" "not linked"; fi
 
-vlog "Adding nu target to shells store"
+vlog "Adding nu target to shells store (flag form)"
 S target add shells -t "$TARGET_NU" -f config.nu >/dev/null 2>&1
-if is_symlink "$TARGET_NU/config.nu"; then pass "target add second target"; else fail "target add second target" "not linked"; fi
+if is_symlink "$TARGET_NU/config.nu"; then pass "target add second target via -t flag"; else fail "target add second target via -t flag" "not linked"; fi
 
-vlog "Modifying fish target files"
-S target modify shells -t "$TARGET_FISH" -f config.fish >/dev/null 2>&1
-if is_symlink "$TARGET_FISH/config.fish"; then pass "target modify updates files"; else fail "target modify updates files" "failed"; fi
+vlog "Modifying fish target files (positional form)"
+S target modify shells "$TARGET_FISH" -f config.fish >/dev/null 2>&1
+if is_symlink "$TARGET_FISH/config.fish"; then pass "target modify accepts positional target"; else fail "target modify accepts positional target" "failed"; fi
 
-vlog "Removing nu target from shells store"
-S target remove shells -t "$TARGET_NU" >/dev/null 2>&1
-if not_exists "$TARGET_NU/config.nu"; then pass "target remove unlinks and removes target"; else fail "target remove unlinks and removes target" "symlink still exists"; fi
+vlog "Removing nu target from shells store (positional form)"
+S target remove shells "$TARGET_NU" >/dev/null 2>&1
+if not_exists "$TARGET_NU/config.nu"; then pass "target remove accepts positional target"; else fail "target remove accepts positional target" "symlink still exists"; fi
 
 # ============================================================
 printf '\n%s\n' "$(bold '=== store remove ===')"


### PR DESCRIPTION
# Accept positional target path on `store target` subcommands

## Summary

Before this PR, `store target add shells -t ~/.config/fish -f config.fish` put the store name positionally but tucked the target path behind a required `-t` flag. Both are identifiers of equal semantic weight — "add target X to store Y" — but only one got the natural positional treatment. Reading the command aloud felt backwards.

This PR accepts the target path as an optional second positional argument on all three `target` subcommands. The `-t`/`--target` flag stays as a long-form alternative so scripts don't break.

## Changes

- `store target add <name> [target]` — target path optional positional
- `store target remove <name> [target]` — same
- `store target modify <name> [target]` — same
- New helper `resolvePositionalTarget` resolves the target from either source and errors clearly if both are supplied.
- Removed the "required" attribute from `-t`/`--target`; the handler now validates that exactly one source is provided.
- Acceptance tests exercise the positional form across all three subcommands.

## Breaking changes

None. The `-t`/`--target` flag continues to work; the positional form is additive.

## Test plan

- [x] `go test ./...` — green
- [x] `bash test.sh` — 63/63 acceptance tests pass
- [x] `store target add shells ~/.config/fish -f config.fish` — positional target
- [x] `store target add shells -t ~/.config/fish -f config.fish` — flag form still works
- [x] `store target add shells ~/x -t ~/y` — errors: both supplied
- [x] `store target add shells` — errors: target required
- [x] `store target remove shells ~/.config/fish` — positional
- [x] `store target modify shells ~/.config/nushell --clear-files -p "*.nu"` — positional + flags compose
