### PR TITLE
Feature/cli dry run coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,7 @@ Updates an existing single-target store. Choose between wholesale replacement, i
 | `--remove-pattern` |       | Remove a pattern from the pattern list; repeatable         |
 | `--clear-files`    |       | Remove all files from the entry                            |
 | `--clear-patterns` |       | Remove all patterns from the entry                         |
+| `--dry-run`        |       | Preview without applying changes                           |
 
 ```sh
 $ store modify nvim -t ~/.config/nvim-custom
@@ -655,6 +656,7 @@ Adds another target to an existing store. The target path may be passed position
 | `--target`   | `-t`  | Target path (or pass positionally)                      |
 | `--files`    | `-f`  | Explicit files to link individually; repeatable         |
 | `--patterns` | `-p`  | Glob patterns to match files; repeatable; supports `**` |
+| `--dry-run`  |       | Preview without applying changes                        |
 
 ```sh
 $ store target add shells ~/.config/fish -f config.fish
@@ -671,9 +673,10 @@ How it works:
 
 Removes one target from a store and unlinks that target's symlinks.
 
-| Flag       | Short | Description                        |
-| ---------- | ----- | ---------------------------------- |
-| `--target` | `-t`  | Target path (or pass positionally) |
+| Flag        | Short | Description                        |
+| ----------- | ----- | ---------------------------------- |
+| `--target`  | `-t`  | Target path (or pass positionally) |
+| `--dry-run` |       | Preview without applying changes   |
 
 ```sh
 $ store target remove shells ~/.config/fish
@@ -704,6 +707,7 @@ Updates the `files` or `patterns` for one target inside a multi-target store. Su
 | `--remove-pattern` |       | Remove a pattern from the pattern list; repeatable         |
 | `--clear-files`    |       | Remove all files from the target                           |
 | `--clear-patterns` |       | Remove all patterns from the target                        |
+| `--dry-run`        |       | Preview without applying changes                           |
 
 ```sh
 $ store target modify shells ~ -f .zshrc -f .bashrc -f .zprofile
@@ -721,13 +725,15 @@ How it works:
 
 Removes the store's symlinked targets and deletes the store entry from config. With `--all`, removes every configured store.
 
-| Flag     | Description                                                       |
-| -------- | ----------------------------------------------------------------- |
-| `--all`  | Remove every configured store                                     |
-| `--yes`  | Skip the confirmation prompt when using `--all`                   |
+| Flag        | Description                                                       |
+| ----------- | ----------------------------------------------------------------- |
+| `--all`     | Remove every configured store                                     |
+| `--yes`     | Skip the confirmation prompt when using `--all`                   |
+| `--dry-run` | Preview without applying changes                                  |
 
 ```sh
 $ store remove nvim
+$ store remove nvim --dry-run
 $ store remove --all
 $ store remove --all --yes
 ```

--- a/cmd/store/commands.go
+++ b/cmd/store/commands.go
@@ -316,6 +316,7 @@ func newTargetAddCmd() *cobra.Command {
 	var target string
 	var files []string
 	var patterns []string
+	var dryRun bool
 
 	cmd := &cobra.Command{
 		Use:   "add <name> [target]",
@@ -330,6 +331,9 @@ The target path may be passed positionally or with -t/--target.`,
 			if err != nil {
 				return err
 			}
+			if dryRun {
+				return previewTargetAdd(args[0], resolved, files, patterns)
+			}
 			return runTargetAdd(args[0], resolved, files, patterns)
 		},
 	}
@@ -337,6 +341,7 @@ The target path may be passed positionally or with -t/--target.`,
 	cmd.Flags().StringVarP(&target, "target", "t", "", "target path for the symlink (or pass positionally)")
 	cmd.Flags().StringArrayVarP(&files, "files", "f", nil, "explicit files to symlink (repeatable)")
 	cmd.Flags().StringArrayVarP(&patterns, "patterns", "p", nil, "glob patterns to match files (repeatable, supports **)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print what would be added without making changes")
 	cmd.ValidArgsFunction = completeStoreNames
 
 	return cmd
@@ -344,6 +349,7 @@ The target path may be passed positionally or with -t/--target.`,
 
 func newTargetRemoveCmd() *cobra.Command {
 	var target string
+	var dryRun bool
 
 	cmd := &cobra.Command{
 		Use:   "remove <name> [target]",
@@ -357,11 +363,15 @@ The target path may be passed positionally or with -t/--target.`,
 			if err != nil {
 				return err
 			}
+			if dryRun {
+				return previewTargetRemove(args[0], resolved)
+			}
 			return runTargetRemove(args[0], resolved)
 		},
 	}
 
 	cmd.Flags().StringVarP(&target, "target", "t", "", "target path to remove (or pass positionally)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print what would be removed without making changes")
 	cmd.ValidArgsFunction = completeStoreNames
 
 	return cmd
@@ -374,6 +384,7 @@ func newTargetModifyCmd() *cobra.Command {
 	var clearFiles bool
 	var clearPatterns bool
 	var ops modifyOps
+	var dryRun bool
 
 	cmd := &cobra.Command{
 		Use:   "modify <name> [target]",
@@ -391,6 +402,9 @@ as clear → replace → add → remove.`,
 			if err != nil {
 				return err
 			}
+			if dryRun {
+				return previewTargetModify(cmd, args[0], resolved, files, patterns, clearFiles, clearPatterns)
+			}
 			return runTargetModify(cmd, args[0], resolved, files, patterns, clearFiles, clearPatterns, ops)
 		},
 	}
@@ -404,6 +418,7 @@ as clear → replace → add → remove.`,
 	cmd.Flags().StringArrayVar(&ops.removePatterns, "remove-pattern", nil, "remove a pattern from the pattern list (repeatable)")
 	cmd.Flags().BoolVar(&clearFiles, "clear-files", false, "remove all files from the target")
 	cmd.Flags().BoolVar(&clearPatterns, "clear-patterns", false, "remove all patterns from the target")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print what would change without applying it")
 	cmd.ValidArgsFunction = completeStoreNames
 
 	return cmd

--- a/cmd/store/commands.go
+++ b/cmd/store/commands.go
@@ -149,6 +149,7 @@ func newModifyCmd() *cobra.Command {
 	var clearFiles bool
 	var clearPatterns bool
 	var ops modifyOps
+	var dryRun bool
 
 	cmd := &cobra.Command{
 		Use:   "modify <name>",
@@ -163,6 +164,9 @@ Flags compose in this order: clear, replace, add, remove.
 The old symlinks are removed before applying changes.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if dryRun {
+				return previewModify(cmd, args[0], target, files, patterns, clearFiles, clearPatterns)
+			}
 			return runModify(cmd, args[0], target, files, patterns, clearFiles, clearPatterns, ops)
 		},
 	}
@@ -176,6 +180,7 @@ The old symlinks are removed before applying changes.`,
 	cmd.Flags().StringArrayVar(&ops.removePatterns, "remove-pattern", nil, "remove a pattern from the pattern list (repeatable)")
 	cmd.Flags().BoolVar(&clearFiles, "clear-files", false, "remove all files from the entry")
 	cmd.Flags().BoolVar(&clearPatterns, "clear-patterns", false, "remove all patterns from the entry")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print what would change without applying it")
 	cmd.ValidArgsFunction = completeStoreNames
 
 	return cmd
@@ -184,6 +189,7 @@ The old symlinks are removed before applying changes.`,
 func newRemoveCmd() *cobra.Command {
 	var all bool
 	var yes bool
+	var dryRun bool
 
 	cmd := &cobra.Command{
 		Use:   "remove <name>",
@@ -198,6 +204,9 @@ confirmation unless --yes is passed.`,
 				if len(args) > 0 {
 					return fmt.Errorf("--all does not accept a store name")
 				}
+				if dryRun {
+					return previewRemoveAll()
+				}
 				if !yes && !promptYesNo("Remove ALL configured stores?") {
 					cmd.SilenceUsage = true
 					return fmt.Errorf("aborted")
@@ -207,24 +216,36 @@ confirmation unless --yes is passed.`,
 			if len(args) == 0 {
 				return fmt.Errorf("specify a store name or use --all")
 			}
+			if dryRun {
+				return previewRemove(args[0])
+			}
 			return runRemove(cmd, args)
 		},
 	}
 	cmd.Flags().BoolVar(&all, "all", false, "remove every configured store")
 	cmd.Flags().BoolVar(&yes, "yes", false, "skip confirmation prompt when using --all")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print what would be removed without making changes")
 	cmd.ValidArgsFunction = completeStoreNames
 	return cmd
 }
 
 func newRemoveAllCmd() *cobra.Command {
-	return &cobra.Command{
+	var dryRun bool
+	cmd := &cobra.Command{
 		Use:        "removeall",
 		Short:      "Remove all store symlinks",
 		Long:       "Removes symlinks and config entries for all stores defined in the config.",
 		Deprecated: "use `store remove --all` instead.",
 		Hidden:     true,
-		RunE:       runRemoveAll,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if dryRun {
+				return previewRemoveAll()
+			}
+			return runRemoveAll(cmd, args)
+		},
 	}
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print what would be removed without making changes")
+	return cmd
 }
 
 func newStatusCmd() *cobra.Command {

--- a/cmd/store/store_ops.go
+++ b/cmd/store/store_ops.go
@@ -219,6 +219,105 @@ func previewRemoveAll() error {
 	return nil
 }
 
+// previewTargetAdd prints the target that would be added to the named store.
+func previewTargetAdd(name, target string, files, patterns []string) error {
+	_, cfg, err := findRootAndConfig()
+	if err != nil {
+		return err
+	}
+	if _, ok := cfg.Stores[name]; !ok {
+		return fmt.Errorf("store %q not found in config", name)
+	}
+	fmt.Printf("%s would add target to store %s:\n", ui.Dim("[dry-run]"), ui.StoreName(name))
+	fmt.Printf("  target:   %s\n", target)
+	if len(files) > 0 {
+		fmt.Printf("  files:    %v\n", files)
+	}
+	if len(patterns) > 0 {
+		fmt.Printf("  patterns: %v\n", patterns)
+	}
+	return nil
+}
+
+// previewTargetRemove prints the target that would be removed from a store.
+func previewTargetRemove(name, target string) error {
+	_, cfg, err := findRootAndConfig()
+	if err != nil {
+		return err
+	}
+	entry, ok := cfg.Stores[name]
+	if !ok {
+		return fmt.Errorf("store %q not found in config", name)
+	}
+	expandedTarget, err := expandTargetPath(target)
+	if err != nil {
+		return err
+	}
+	found := false
+	for _, t := range entry.ResolvedTargets() {
+		expandedExisting, err := expandTargetPath(t.Target)
+		if err != nil {
+			return err
+		}
+		if expandedExisting == expandedTarget {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("store %q has no target %q", name, target)
+	}
+	fmt.Printf("%s would remove target %s from store %s\n", ui.Dim("[dry-run]"), ui.TargetPath(target), ui.StoreName(name))
+	return nil
+}
+
+// previewTargetModify prints the would-be post-modification target entry.
+func previewTargetModify(cmd *cobra.Command, name, target string, files, patterns []string, clearFiles, clearPatterns bool) error {
+	_, cfg, err := findRootAndConfig()
+	if err != nil {
+		return err
+	}
+	entry, ok := cfg.Stores[name]
+	if !ok {
+		return fmt.Errorf("store %q not found in config", name)
+	}
+	expandedTarget, err := expandTargetPath(target)
+	if err != nil {
+		return err
+	}
+	entry.MigrateToMultiTarget()
+	var found *config.TargetEntry
+	for i := range entry.Targets {
+		expandedExisting, err := expandTargetPath(entry.Targets[i].Target)
+		if err != nil {
+			return err
+		}
+		if expandedExisting == expandedTarget {
+			found = &entry.Targets[i]
+			break
+		}
+	}
+	if found == nil {
+		return fmt.Errorf("store %q has no target %q", name, target)
+	}
+	if cmd.Flags().Changed("files") {
+		found.Files = files
+	}
+	if clearFiles {
+		found.Files = nil
+	}
+	if cmd.Flags().Changed("patterns") {
+		found.Patterns = patterns
+	}
+	if clearPatterns {
+		found.Patterns = nil
+	}
+	fmt.Printf("%s would modify target %s on store %s:\n", ui.Dim("[dry-run]"), ui.TargetPath(target), ui.StoreName(name))
+	fmt.Printf("  files:    %v\n", found.Files)
+	fmt.Printf("  patterns: %v\n", found.Patterns)
+	return nil
+}
+
 // previewModify prints the would-be new entry after applying the provided modifications.
 func previewModify(cmd *cobra.Command, name, target string, files, patterns []string, clearFiles, clearPatterns bool) error {
 	_, cfg, err := findRootAndConfig()

--- a/cmd/store/store_ops.go
+++ b/cmd/store/store_ops.go
@@ -182,6 +182,78 @@ func runStoreAll(cmd *cobra.Command, args []string) error {
 	return err
 }
 
+// previewRemove prints what runRemove would do without touching config or filesystem.
+func previewRemove(name string) error {
+	_, cfg, err := findRootAndConfig()
+	if err != nil {
+		return err
+	}
+	entry, ok := cfg.Stores[name]
+	if !ok {
+		return fmt.Errorf("store %q not found in config", name)
+	}
+	targets := entry.ResolvedTargets()
+	fmt.Printf("%s would remove store %s (%d target(s))\n", ui.Dim("[dry-run]"), ui.StoreName(name), len(targets))
+	for _, t := range targets {
+		fmt.Printf("  - unlink %s\n", ui.TargetPath(t.Target))
+	}
+	return nil
+}
+
+// previewRemoveAll prints what runRemoveAll would do without touching anything.
+func previewRemoveAll() error {
+	_, cfg, err := findRootAndConfig()
+	if err != nil {
+		return err
+	}
+	if len(cfg.Stores) == 0 {
+		fmt.Println(ui.Dim("[dry-run]") + " no stores configured")
+		return nil
+	}
+	stores := selectStores(cfg.Stores, onlyStores)
+	stores = filterStoresByPlatform(stores, platform.Detect())
+	fmt.Printf("%s would remove %d store(s):\n", ui.Dim("[dry-run]"), len(stores))
+	for name, entry := range stores {
+		fmt.Printf("  - %s (%s)\n", ui.StoreName(name), ui.TargetPath(entry.Target))
+	}
+	return nil
+}
+
+// previewModify prints the would-be new entry after applying the provided modifications.
+func previewModify(cmd *cobra.Command, name, target string, files, patterns []string, clearFiles, clearPatterns bool) error {
+	_, cfg, err := findRootAndConfig()
+	if err != nil {
+		return err
+	}
+	entry, ok := cfg.Stores[name]
+	if !ok {
+		return fmt.Errorf("store %q not found in config", name)
+	}
+	if entry.IsMultiTarget() {
+		return fmt.Errorf("store %q uses multiple targets; use 'store target modify' instead", name)
+	}
+	if cmd.Flags().Changed("target") {
+		entry.Target = target
+	}
+	if cmd.Flags().Changed("files") {
+		entry.Files = files
+	}
+	if clearFiles {
+		entry.Files = nil
+	}
+	if cmd.Flags().Changed("patterns") {
+		entry.Patterns = patterns
+	}
+	if clearPatterns {
+		entry.Patterns = nil
+	}
+	fmt.Printf("%s would modify store %s:\n", ui.Dim("[dry-run]"), ui.StoreName(name))
+	fmt.Printf("  target:   %s\n", entry.Target)
+	fmt.Printf("  files:    %v\n", entry.Files)
+	fmt.Printf("  patterns: %v\n", entry.Patterns)
+	return nil
+}
+
 func runRemove(cmd *cobra.Command, args []string) error {
 	_ = cmd
 

--- a/test.sh
+++ b/test.sh
@@ -260,6 +260,14 @@ if not_exists "$TARGET_NU/config.nu"; then pass "target remove accepts positiona
 printf '\n%s\n' "$(bold '=== store remove ===')"
 # ============================================================
 
+vlog "Dry-run remove configs (no changes)"
+out=$(S remove configs --dry-run 2>&1)
+if [[ "$out" == *"would remove"* ]] && is_symlink "$TARGET_CONFIGS/app.conf"; then
+    pass "remove --dry-run previews without unlinking"
+else
+    fail "remove --dry-run previews without unlinking" "expected dry-run message and symlink intact"
+fi
+
 vlog "Removing configs store"
 S remove configs >/dev/null 2>&1
 if not_exists "$TARGET_CONFIGS/app.conf"; then pass "remove deletes symlinks and config entry"; else fail "remove deletes symlinks and config entry" "symlink still exists"; fi


### PR DESCRIPTION
# Add `--dry-run` to every mutating command

## Summary

Preview coverage across the CLI was inconsistent before this PR: `store import` and `store adopt` had `--dry-run`, the apply path had `store diff`, but `store modify`, `store remove` (single and bulk), and the entire `target` family had no way to preview changes. A user about to run `store target remove shells -t ~/.config/fish` had to cross their fingers and hit enter.

This PR adds `--dry-run` everywhere a command would mutate the filesystem or `.store/config.yaml`.

## Changes

New `--dry-run` flag on:

- `store modify` — prints the would-be post-modification entry
- `store remove` — prints the store and targets that would be unlinked
- `store remove --all` — prints the full list of stores that would be removed
- `store removeall` (deprecated alias) — same
- `store target add` — prints the target that would be added
- `store target remove` — prints the target that would be removed
- `store target modify` — prints the would-be post-modification target entry

Each preview runs through the same resolution logic as the real command (finding the store, resolving the target by normalized path) so dry-run errors match real errors when the arguments are wrong.

Flag help across all affected commands now reflects the new surface.

## Breaking changes

None.

## Test plan

- [x] `go test ./...` — green
- [x] `bash test.sh` — 66/66 acceptance tests pass (1 new case)
- [x] `store remove nvim --dry-run` prints preview and leaves the symlink intact
- [x] `store remove --all --dry-run` prints the full list without prompting or removing
- [x] `store modify shells -f .zshrc --dry-run` prints would-be entry, config unchanged
- [x] `store target add shells -t ~/x -f foo --dry-run` prints would-be target, no symlinks created
- [x] `store target remove shells -t ~/.config/fish --dry-run` prints would-be removal, symlink intact
- [x] `store target modify shells -t ~ --clear-files --dry-run` prints would-be target, config unchanged
