### PR TITLE
Feature/cli polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,13 +480,13 @@ Reconciles all configured stores: creates missing symlinks, replaces broken ones
 
 Running `store` with no arguments prints help; `store apply` is the explicit verb that performs the reconciliation.
 
-| Flag      | Description                              |
-| --------- | ---------------------------------------- |
-| `--only`  | Apply only the named stores (repeatable) |
-| `--force` | Create `.bak` backups without prompting  |
+| Flag      | Short | Description                              |
+| --------- | ----- | ---------------------------------------- |
+| `--only`  | `-o`  | Apply only the named stores (repeatable) |
+| `--force` |       | Create `.bak` backups without prompting  |
 
 ```sh
-$ store apply --only nvim --only git
+$ store apply -o nvim -o git
 $ store apply --force
 ```
 
@@ -785,7 +785,7 @@ Previews what `store apply` would do without changing anything.
 
 | Flag     | Description                                |
 | -------- | ------------------------------------------ |
-| `--only` | Preview only the named stores (repeatable) |
+| `--only` (`-o`) | Preview only the named stores (repeatable) |
 
 ```sh
 $ store diff
@@ -869,7 +869,7 @@ $ store secret set api_key "super-secret"
 
 How it works:
 
-- If `value` is omitted, `store` prompts for it with hidden input.
+- If `value` is omitted, `store` prompts for it with hidden input. This is the recommended form; passing the value as an argument exposes it to shell history and process listings, and `store` prints a warning when you do.
 - Reads the passphrase from `STORE_PASSPHRASE` or prompts interactively.
 
 ### `store secret get <name>`

--- a/cmd/store/commands.go
+++ b/cmd/store/commands.go
@@ -51,7 +51,7 @@ replace broken ones, and report conflicts. Run this after cloning a dotfiles
 repo on a new machine, or after changing .store/config.yaml.`,
 		RunE: runStoreAll,
 	}
-	cmd.Flags().StringArrayVar(&onlyStores, "only", nil, "apply only the named stores (repeatable)")
+	cmd.Flags().StringArrayVarP(&onlyStores, "only", "o", nil, "apply only the named stores (repeatable)")
 	return cmd
 }
 
@@ -272,7 +272,7 @@ func newDiffCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringArrayVar(&diffOnly, "only", nil, "only diff specific entries by name (repeatable)")
+	cmd.Flags().StringArrayVarP(&diffOnly, "only", "o", nil, "only diff specific entries by name (repeatable)")
 	return cmd
 }
 

--- a/cmd/store/secret_ops.go
+++ b/cmd/store/secret_ops.go
@@ -21,6 +21,7 @@ func runSecretSet(cmd *cobra.Command, args []string) error {
 	value := ""
 	if len(args) == 2 {
 		value = args[1]
+		fmt.Fprintln(cmd.ErrOrStderr(), ui.Dim("  warning: passing a secret value as an argument may be logged by your shell history; prefer interactive input"))
 	} else {
 		value, err = promptHiddenValue("Enter secret value: ", "failed to read secret value")
 		if err != nil {


### PR DESCRIPTION
# Polish: `-o` short flag for `--only`; warn on inline secret values

## Summary

Two small quality-of-life tweaks that came out of the CLI surface review.

`--only` is one of the most-typed flags on `store apply` and `store diff` — no short alias made scripts and one-off invocations more verbose than they needed to be. And `store secret set <name> <value>` quietly recorded secrets in shell history without so much as a warning.

## Changes

- **`-o` short flag for `--only`** on `store apply` and `store diff`. `store apply -o nvim -o git` works like the long form.
- **Shell-history warning on `store secret set <name> <value>`**: when the value is passed inline instead of prompted, print a stderr warning that the value may be captured by shell history or process listings. The command still succeeds.
- **README**: flag tables updated to show the `-o` short alias; the `secret set` section calls out the inline-value risk.

## Breaking changes

None.

## Test plan

- [x] `go test ./...` — green
- [x] `bash test.sh` — 66/66 acceptance tests pass
- [x] `store apply -o nvim` filters correctly
- [x] `store diff -o nvim` filters correctly
- [x] `store secret set token foo` prints a stderr warning and still sets the secret
- [x] `store secret set token` (no inline value) prompts for hidden input without warning
