### PR TITLE
Nested store groups and a collapsible tree view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to `store` are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.0] - 2026-04-25
+
+### Added
+
+- **Nested groups in `config.yaml`.** Once you have more than a handful of
+  stores, slash-named keys like `desktop/hyprland` get noisy. You can now
+  group them under plain YAML maps and the resulting store names are
+  derived from the keys joined with `/`. A map is treated as a store
+  entry when it has `target`, `targets`, `files`, `patterns`, `ignore`,
+  `hooks`, or `when`; otherwise it's a group containing more stores.
+  Old flat configs still load unchanged. Any time `store` writes the file
+  back, the nested form is the default. If a name like `shells` is also
+  the prefix of another name like `shells/fish`, those entries fall back
+  to flat slash keys so both stay addressable.
+- **Collapsible tree view in the TUI.** When stores share a slash-prefix,
+  the ledger collapses them under a group header. `+` means collapsed,
+  `−` means open. The group row shows an aggregate state and a count of
+  stores beneath it, so you can scan the top of the file at a glance and
+  drill in only where you need to. Filter mode flattens the tree so a
+  search hits every store regardless of where it lives.
+
+### Changed
+
+- **TUI keymap.** `l` / `→` and `h` / `←` are now tree-aware. `l` expands
+  a group or opens the action menu on a leaf. `h` collapses the current
+  group or jumps from a child row to its parent. `esc` still clears an
+  active filter and closes overlays. `enter` and `space` toggle a
+  group's expand state when the cursor is on a header row, and behave as
+  before on leaf rows.
+
 ## [2.4.0] - 2026-04-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -300,12 +300,42 @@ stores:
           - "*.bak"
 ```
 
+Nested groups:
+
+Once you have more than a handful of stores, slash-named keys like
+`desktop/hyprland` start to feel cluttered. You can group them under a
+plain YAML map instead, and the resulting store names are derived from
+the keys joined with `/`:
+
+```yaml
+stores:
+  desktop:
+    hyprland:
+      target: "~/.config/hypr"
+    waybar:
+      target: "~/.config/waybar"
+  editors:
+    neovim:
+      target: "~/.config/nvim"
+  kmonad:
+    target: "~/.config/kmonad"
+```
+
+That config defines four stores: `desktop/hyprland`, `desktop/waybar`,
+`editors/neovim`, and `kmonad`. The store directories on disk still live
+at the same paths as the slash-joined names. Both forms read the same way
+internally, so you can freely mix them, and any store you add or modify
+through the CLI or TUI is saved back in the nested form when there is no
+ambiguity.
+
 Rules:
 
 - A store may use either `target` or `targets`, not both.
 - In multi-target mode, `files`, `patterns`, and `ignore` belong inside each `targets[]` entry.
 - If a store entry has no target yet, it is valid config but nothing is linked.
 - `vars` is a top-level map alongside `stores`; values are accessible in templates as `{{ .Vars.key }}`.
+- A YAML map is treated as a store entry when it has any of `target`, `targets`, `files`, `patterns`, `ignore`, `hooks`, or `when`. Otherwise it is treated as a group containing more stores.
+- A store name and a group cannot share a path. If you have both `shells` (a store) and `shells/fish` (another store), the file falls back to flat slash keys for those entries so each one stays addressable.
 
 ### Top-level store fields
 
@@ -550,26 +580,24 @@ Implementation details a user might bump into at the edges. You don't need this 
 
 ## Interactive TUI
 
-`store tui` opens a keyboard-driven dashboard. Every CLI verb is reachable from inside it — a handful via single-letter bindings, the rest through the `:` command palette. The dashboard reads as a single vertical column: a ledger of your stores on top, the selected store's detail below, and the recent activity log beneath that. No panes, no outer frame.
+`store tui` opens a keyboard-driven dashboard. Every CLI verb is reachable from inside it. A handful run through single-letter bindings, the rest through the `:` command palette. The dashboard reads as a single vertical column: a ledger of your stores on top, the selected store's detail below, and the recent activity log beneath that. No panes, no outer frame.
 
 ```text
   store                                        ~/dotfiles   linux/amd64  ·
 
-  ─── 4 stores ·  3 linked  1 missing ─────────────────────────────────
+  ─── 8 stores ·  6 linked  2 missing ─────────────────────────────────
 
-     nvim      ~/.config/nvim                             ●  linked
-     shells    3 targets                                  ◐  partial
-     git       ~/.config/git                              ●  linked
-  ▸  tmux      ~/.config/tmux                             ○  missing
+  ▸  + desktop    4 stores                                  ●  linked
+     + editors    1 store                                   ●  linked
+     − shells
+        fish      ~/.config/fish                            ●  linked
+        nushell   ~/.config/nushell                         ○  missing
+     + tools      1 store                                   ●  linked
+       kmonad     ~/.config/kmonad                          ●  linked
 
-  ─── tmux ──────────────────────────────────────────────── missing ─
+  ─── desktop/ ────────────────────────────── 4 stores  linked ─
 
-    target     ~/.config/tmux
-    mode       whole directory
-
-    files
-      ○  tmux.conf
-      ○  plugins/tpm
+    press l or enter to expand
 
   ─── recent ─────────────────────────────────────────────────────────
 
@@ -577,6 +605,11 @@ Implementation details a user might bump into at the edges. You don't need this 
 
   j/k move   enter actions   space toggle   / filter   : command   ? help
 ```
+
+When stores share a slash-prefix, the ledger groups them under a header
+row so you can scan the top level first. A `+` next to the group means
+collapsed; a `−` means open. Top-level stores (no slash in the name) sit
+alongside groups at the same indent.
 
 ### Keymap
 
@@ -586,18 +619,20 @@ Implementation details a user might bump into at the edges. You don't need this 
 | --- | ------ |
 | `j` / `k` | Move up / down the store list |
 | `g` / `G` | Top / bottom |
-| `esc` / `h` | Back · close the top overlay |
+| `l` / `→` | Expand a group, or open the action menu on a leaf store |
+| `h` / `←` | Collapse the current group, or jump from a child row to its parent |
+| `esc` | Back. Clears an active filter and closes the top overlay |
 
 **Stores**
 
 | Key | Action |
 | --- | ------ |
-| `enter` | Open the action menu for the selected store |
-| `space` | Quick toggle: link if missing, unlink if linked |
-| `d` | Diff — preview to the activity log |
+| `enter` | Toggle a group's expand state, or open the action menu on a leaf store |
+| `space` | Toggle a group's expand state, or link / unlink the selected store |
+| `d` | Diff. Preview to the activity log |
 | `A` | Apply all (reconcile every store) |
 | `R` | Remove the selected store (typed confirmation required) |
-| `/` | Filter the store list live |
+| `/` | Filter the store list live. Filter mode flattens matches across all groups |
 
 **Commands**
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	core "github.com/cushycush/store-core/config"
 	"gopkg.in/yaml.v3"
@@ -163,9 +165,250 @@ func (e *StoreEntry) MigrateToSingleTarget() {
 }
 
 // Config represents the full .store/config.yaml file.
+//
+// The on-disk YAML may write `stores:` as either a flat mapping where keys
+// embed slashes ("desktop/hyprland: ...") or as a nested mapping where
+// groups contain stores ("desktop:\n  hyprland: ..."). Both forms parse
+// into the same flat `Stores` map keyed by full slash path; the tree view
+// in the TUI derives its hierarchy from those slashes. On Save, the
+// config writes back nested when there are no name collisions, and falls
+// back to flat keys when a store name is also a prefix of another name.
 type Config struct {
-	Stores map[string]StoreEntry `yaml:"stores"`
-	Vars   map[string]string     `yaml:"vars,omitempty"`
+	Stores map[string]StoreEntry `yaml:"-"`
+	Vars   map[string]string     `yaml:"-"`
+}
+
+// storeFieldSet enumerates the keys that mark a YAML mapping as a store
+// entry rather than a nested group. Anything else at that level is a group
+// containing more stores.
+var storeFieldSet = map[string]bool{
+	"target":   true,
+	"targets":  true,
+	"files":    true,
+	"patterns": true,
+	"ignore":   true,
+	"hooks":    true,
+	"when":     true,
+}
+
+// UnmarshalYAML parses either flat or nested `stores:` mappings.
+func (c *Config) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
+		node = node.Content[0]
+	}
+	c.Stores = make(map[string]StoreEntry)
+	c.Vars = nil
+	if node.Kind == yaml.ScalarNode && node.Value == "" {
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("config: expected mapping, got %s", yamlKindName(node.Kind))
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		k := node.Content[i]
+		v := node.Content[i+1]
+		switch k.Value {
+		case "stores":
+			if err := unmarshalStores(v, "", c.Stores); err != nil {
+				return err
+			}
+		case "vars":
+			if v.Kind == yaml.ScalarNode && v.Value == "" {
+				continue
+			}
+			if err := v.Decode(&c.Vars); err != nil {
+				return fmt.Errorf("vars: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+// MarshalYAML emits a nested `stores:` mapping where possible. When a store
+// name is also a prefix of another (e.g. both "shells" and "shells/fish"
+// exist), the whole tree falls back to flat slash-paths so the output is
+// unambiguous.
+func (c Config) MarshalYAML() (any, error) {
+	root := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	storesNode, err := buildStoresNode(c.Stores)
+	if err != nil {
+		return nil, err
+	}
+	root.Content = append(root.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Value: "stores"},
+		storesNode,
+	)
+	if len(c.Vars) > 0 {
+		varsNode := &yaml.Node{}
+		if err := varsNode.Encode(c.Vars); err != nil {
+			return nil, fmt.Errorf("vars: %w", err)
+		}
+		root.Content = append(root.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Value: "vars"},
+			varsNode,
+		)
+	}
+	return root, nil
+}
+
+func unmarshalStores(node *yaml.Node, prefix string, out map[string]StoreEntry) error {
+	if node.Kind == yaml.ScalarNode && node.Value == "" {
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("stores: expected mapping at %q", prefix)
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		k := node.Content[i]
+		v := node.Content[i+1]
+		name := k.Value
+		if prefix != "" {
+			name = prefix + "/" + name
+		}
+		if v.Kind == yaml.MappingNode && !isStoreEntryNode(v) {
+			if err := unmarshalStores(v, name, out); err != nil {
+				return err
+			}
+			continue
+		}
+		var entry StoreEntry
+		if v.Kind == yaml.MappingNode {
+			if err := v.Decode(&entry); err != nil {
+				return fmt.Errorf("store %q: %w", name, err)
+			}
+		}
+		// Scalar null leaves entry zero-valued; Validate emits the warning.
+		out[name] = entry
+	}
+	return nil
+}
+
+func isStoreEntryNode(node *yaml.Node) bool {
+	if node.Kind != yaml.MappingNode {
+		return false
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if storeFieldSet[node.Content[i].Value] {
+			return true
+		}
+	}
+	return false
+}
+
+func buildStoresNode(stores map[string]StoreEntry) (*yaml.Node, error) {
+	out := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	if len(stores) == 0 {
+		return out, nil
+	}
+
+	names := make([]string, 0, len(stores))
+	for n := range stores {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	if hasPrefixCollision(names) {
+		// Fall back to flat slash-paths so every entry remains addressable.
+		for _, name := range names {
+			v := &yaml.Node{}
+			if err := v.Encode(stores[name]); err != nil {
+				return nil, fmt.Errorf("encode %q: %w", name, err)
+			}
+			out.Content = append(out.Content,
+				&yaml.Node{Kind: yaml.ScalarNode, Value: name},
+				v,
+			)
+		}
+		return out, nil
+	}
+
+	type tnode struct {
+		isStore  bool
+		entry    StoreEntry
+		children map[string]*tnode
+	}
+	root := &tnode{children: map[string]*tnode{}}
+	for _, name := range names {
+		parts := strings.Split(name, "/")
+		cur := root
+		for i, p := range parts {
+			child, ok := cur.children[p]
+			if !ok {
+				child = &tnode{children: map[string]*tnode{}}
+				cur.children[p] = child
+			}
+			if i == len(parts)-1 {
+				child.isStore = true
+				child.entry = stores[name]
+			}
+			cur = child
+		}
+	}
+
+	var emit func(parent *yaml.Node, t *tnode) error
+	emit = func(parent *yaml.Node, t *tnode) error {
+		keys := make([]string, 0, len(t.children))
+		for k := range t.children {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			child := t.children[k]
+			keyNode := &yaml.Node{Kind: yaml.ScalarNode, Value: k}
+			if child.isStore {
+				v := &yaml.Node{}
+				if err := v.Encode(child.entry); err != nil {
+					return err
+				}
+				parent.Content = append(parent.Content, keyNode, v)
+				continue
+			}
+			v := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+			if err := emit(v, child); err != nil {
+				return err
+			}
+			parent.Content = append(parent.Content, keyNode, v)
+		}
+		return nil
+	}
+	if err := emit(out, root); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// hasPrefixCollision reports whether any name is also a slash-prefix of
+// another. When that happens the nested form would have to make a single
+// key both a leaf entry and a parent group, so we emit flat instead.
+func hasPrefixCollision(sortedNames []string) bool {
+	for i, n := range sortedNames {
+		for j := i + 1; j < len(sortedNames); j++ {
+			m := sortedNames[j]
+			if !strings.HasPrefix(m, n) {
+				break
+			}
+			if len(m) > len(n) && m[len(n)] == '/' {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func yamlKindName(k yaml.Kind) string {
+	switch k {
+	case yaml.ScalarNode:
+		return "scalar"
+	case yaml.SequenceNode:
+		return "sequence"
+	case yaml.MappingNode:
+		return "mapping"
+	case yaml.AliasNode:
+		return "alias"
+	case yaml.DocumentNode:
+		return "document"
+	}
+	return "unknown"
 }
 
 // ConfigPath returns the path to the config file given a repo root.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -372,6 +372,149 @@ func TestStoreEntryMigrateToSingleTarget(t *testing.T) {
 	}
 }
 
+func TestLoadNestedStores(t *testing.T) {
+	root := t.TempDir()
+	writeConfigFile(t, root, `stores:
+  desktop:
+    hyprland:
+      target: ~/.config/hypr
+    waybar:
+      target: ~/.config/waybar
+  editors:
+    neovim:
+      target: ~/.config/nvim
+  kmonad:
+    target: ~/.config/kmonad
+`)
+	cfg, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	want := map[string]string{
+		"desktop/hyprland": "~/.config/hypr",
+		"desktop/waybar":   "~/.config/waybar",
+		"editors/neovim":   "~/.config/nvim",
+		"kmonad":           "~/.config/kmonad",
+	}
+	if len(cfg.Stores) != len(want) {
+		t.Fatalf("Stores has %d entries, want %d (%#v)", len(cfg.Stores), len(want), cfg.Stores)
+	}
+	for name, target := range want {
+		got, ok := cfg.Stores[name]
+		if !ok {
+			t.Errorf("missing store %q", name)
+			continue
+		}
+		if got.Target != target {
+			t.Errorf("store %q target = %q, want %q", name, got.Target, target)
+		}
+	}
+}
+
+func TestLoadFlatStoresStillWorks(t *testing.T) {
+	root := t.TempDir()
+	writeConfigFile(t, root, `stores:
+  desktop/hyprland:
+    target: ~/.config/hypr
+  editors/neovim:
+    target: ~/.config/nvim
+`)
+	cfg, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if got, want := cfg.Stores["desktop/hyprland"].Target, "~/.config/hypr"; got != want {
+		t.Errorf("desktop/hyprland target = %q, want %q", got, want)
+	}
+	if got, want := cfg.Stores["editors/neovim"].Target, "~/.config/nvim"; got != want {
+		t.Errorf("editors/neovim target = %q, want %q", got, want)
+	}
+}
+
+func TestLoadMixedFlatAndNested(t *testing.T) {
+	root := t.TempDir()
+	writeConfigFile(t, root, `stores:
+  desktop:
+    hyprland:
+      target: ~/.config/hypr
+  editors/neovim:
+    target: ~/.config/nvim
+  kmonad:
+    target: ~/.config/kmonad
+`)
+	cfg, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	for _, name := range []string{"desktop/hyprland", "editors/neovim", "kmonad"} {
+		if _, ok := cfg.Stores[name]; !ok {
+			t.Errorf("missing store %q", name)
+		}
+	}
+}
+
+func TestSaveEmitsNestedWhenPossible(t *testing.T) {
+	root := t.TempDir()
+	cfg := &Config{Stores: map[string]StoreEntry{
+		"desktop/hyprland": {Target: "~/.config/hypr"},
+		"desktop/waybar":   {Target: "~/.config/waybar"},
+		"kmonad":           {Target: "~/.config/kmonad"},
+	}}
+	if err := Save(root, cfg); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	data, err := os.ReadFile(ConfigPath(root))
+	if err != nil {
+		t.Fatalf("ReadFile error = %v", err)
+	}
+	got := string(data)
+	if !strings.Contains(got, "desktop:") {
+		t.Errorf("output missing 'desktop:' group header:\n%s", got)
+	}
+	if strings.Contains(got, "desktop/hyprland:") {
+		t.Errorf("output should nest hyprland under desktop, but kept flat key:\n%s", got)
+	}
+	// Reload and confirm the flat names round-trip identically.
+	loaded, err := Load(root)
+	if err != nil {
+		t.Fatalf("reload error = %v", err)
+	}
+	for _, name := range []string{"desktop/hyprland", "desktop/waybar", "kmonad"} {
+		if _, ok := loaded.Stores[name]; !ok {
+			t.Errorf("after round-trip, store %q missing", name)
+		}
+	}
+}
+
+func TestSaveFallsBackToFlatOnPrefixCollision(t *testing.T) {
+	root := t.TempDir()
+	cfg := &Config{Stores: map[string]StoreEntry{
+		"shells":      {Target: "~"},
+		"shells/fish": {Target: "~/.config/fish"},
+	}}
+	if err := Save(root, cfg); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	data, err := os.ReadFile(ConfigPath(root))
+	if err != nil {
+		t.Fatalf("ReadFile error = %v", err)
+	}
+	got := string(data)
+	if !strings.Contains(got, "shells/fish:") {
+		t.Errorf("output should keep flat slash key for collision:\n%s", got)
+	}
+	loaded, err := Load(root)
+	if err != nil {
+		t.Fatalf("reload error = %v", err)
+	}
+	if _, ok := loaded.Stores["shells/fish"]; !ok {
+		t.Errorf("after round-trip, shells/fish missing")
+	}
+	if _, ok := loaded.Stores["shells"]; !ok {
+		t.Errorf("after round-trip, shells missing")
+	}
+}
+
 func TestConfigLoadSaveRoundTrip(t *testing.T) {
 	root := t.TempDir()
 	want := &Config{

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -35,11 +35,13 @@ func (o *Help) View() string {
 		{"move", []row{
 			{"j · k", "up and down"},
 			{"g · G", "top and bottom"},
-			{"esc · h", "back · close overlay"},
+			{"l · →", "expand group · drill into store"},
+			{"h · ←", "collapse group · jump to parent"},
+			{"esc", "back · clear filter · close overlay"},
 		}},
 		{"stores", []row{
-			{"enter", "actions for the selected store"},
-			{"space", "link if missing, unlink if linked"},
+			{"enter", "actions for the selected store · toggle group"},
+			{"space", "link if missing, unlink if linked · toggle group"},
 			{"d", "diff — preview to the activity log"},
 			{"A", "apply all (reconcile every store)"},
 			{"R", "remove the selected store (confirmed)"},

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -21,6 +21,12 @@ type Keymap struct {
 	ApplyAll key.Binding
 	Diff     key.Binding
 	Remove   key.Binding
+
+	// Tree navigation. Expand opens a group (or moves into the actions
+	// menu on a leaf); Collapse shuts a group (or jumps to its parent
+	// from a child row).
+	Expand   key.Binding
+	Collapse key.Binding
 }
 
 // DefaultKeymap returns the canonical keymap.
@@ -47,6 +53,9 @@ func DefaultKeymap() Keymap {
 		ApplyAll: key.NewBinding(key.WithKeys("A"), key.WithHelp("A", "apply all")),
 		Diff:     key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "diff")),
 		Remove:   key.NewBinding(key.WithKeys("R"), key.WithHelp("R", "remove")),
+
+		Expand:   key.NewBinding(key.WithKeys("l", "right"), key.WithHelp("l", "expand")),
+		Collapse: key.NewBinding(key.WithKeys("left"), key.WithHelp("←", "collapse")),
 	}
 }
 

--- a/internal/tui/keys_test.go
+++ b/internal/tui/keys_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 // TestKeymapNoCollisions verifies that no two distinct top-level bindings
-// share a key trigger. `j/k/g/G/h` are reserved for movement and cannot be
-// bound to actions. Overlay-local keys (e.g. `a` for add secret) are
+// share a key trigger. `j/k/g/G/h/l` are reserved for movement and cannot
+// be bound to actions. Overlay-local keys (e.g. `a` for add secret) are
 // scoped and don't appear in the global keymap.
 func TestKeymapNoCollisions(t *testing.T) {
 	km := DefaultKeymap()
@@ -19,6 +19,7 @@ func TestKeymapNoCollisions(t *testing.T) {
 		"Filter": km.Filter, "Palette": km.Palette, "Help": km.Help,
 		"Activity": km.Activity, "Refresh": km.Refresh, "Quit": km.Quit,
 		"ApplyAll": km.ApplyAll, "Diff": km.Diff, "Remove": km.Remove,
+		"Expand": km.Expand, "Collapse": km.Collapse,
 	}
 	for label, b := range bindings {
 		for _, k := range b.Keys() {
@@ -38,10 +39,13 @@ func TestKeymapNoCollisions(t *testing.T) {
 
 // TestVimMovementNotOverloaded asserts the design principle: h/j/k/l/g/G
 // are reserved for movement and are never bound to mutating actions.
+// Tree expand/collapse counts as movement (file-tree convention) so `l`
+// and `h` aliases Back/Expand which is consistent with that.
 func TestVimMovementNotOverloaded(t *testing.T) {
 	km := DefaultKeymap()
-	forbidden := map[string]bool{"j": true, "k": true, "g": true, "G": true, "l": true}
-	// `h` aliases Back, which is intentional (close overlay in single-column).
+	forbidden := map[string]bool{"j": true, "k": true, "g": true, "G": true}
+	// `h` aliases Back (and doubles as collapse-or-jump-to-parent in the
+	// tree view); `l` aliases Expand which is movement, not mutation.
 	actions := []key.Binding{
 		km.Enter, km.Space, km.Filter, km.Palette, km.Help,
 		km.Activity, km.Refresh, km.ApplyAll, km.Diff, km.Remove,

--- a/internal/tui/stores.go
+++ b/internal/tui/stores.go
@@ -11,47 +11,81 @@ import (
 	storeops "github.com/cushycush/store/v2/internal/store"
 )
 
-// Row is a single store row in the ledger.
+// Row is a single visible line in the ledger. It is either a leaf store row
+// or a group row aggregating descendants. Groups exist when store names
+// share a slash-prefix (e.g. desktop/hyprland and desktop/waybar).
 type Row struct {
-	Name    string
-	Summary string // target path, or "N targets"
-	State   State
-	Fresh   float64 // 0..1 spark intensity for fresh-change flourish
+	// Name is the full slash path. For groups, the group path ("desktop").
+	// For stores, the full store key ("desktop/hyprland").
+	Name string
+	// Display is the rendered label: leaf segment when nested, full path
+	// when at depth 0 or in flattened filter mode.
+	Display string
+	// Depth is the number of parent groups preceding this row.
+	Depth int
+	// IsGroup marks group rows so navigation/actions can branch.
+	IsGroup bool
+	// Expanded reports whether a group's children are currently visible.
+	Expanded bool
+	// DescendantCount is the number of leaf stores under a group.
+	DescendantCount int
+	// Summary is the dim right-side hint (target path or "N stores").
+	Summary string
+	// State is the aggregate (for groups) or per-store state.
+	State State
+	// Fresh is the spark intensity (0..1) for the fresh-change flourish.
+	Fresh float64
 }
 
 // Stores holds the state of the ledger row list.
 type Stores struct {
-	all    []Row
+	// data holds per-store info keyed by full slash name. Recomputed by
+	// Refresh from a loaded config + on-disk state.
+	data map[string]storeData
+	// names is the sorted list of full slash names from the last refresh.
+	names []string
+	// expanded maps group full-path → true. Missing keys are collapsed.
+	// Persists across refreshes so the user's expansion state survives
+	// config reloads.
+	expanded map[string]bool
+
 	view   []Row
 	filter string
 	cursor int
 }
 
+// storeData holds the per-store fields produced by Refresh that get
+// projected into the visible Row.
+type storeData struct {
+	state   State
+	summary string
+	fresh   float64
+}
+
 // NewStores returns an empty list. Populate with Refresh.
 func NewStores() *Stores {
-	return &Stores{}
+	return &Stores{
+		data:     map[string]storeData{},
+		expanded: map[string]bool{},
+	}
 }
 
 // Refresh rebuilds rows from a loaded config, computing aggregate status
 // for every store. freshMarks stamps the moment each store's state last
 // changed; the renderer uses that to draw the fresh-change spark.
 func (s *Stores) Refresh(root string, cfg *config.Config, freshMarks map[string]time.Time, now time.Time) {
-	prev := make(map[string]State, len(s.all))
-	for _, r := range s.all {
-		prev[r.Name] = r.State
-	}
+	prev := s.data
+	s.data = make(map[string]storeData, len(prev))
+	s.names = s.names[:0]
 
-	var names []string
 	if cfg != nil {
-		names = make([]string, 0, len(cfg.Stores))
 		for n := range cfg.Stores {
-			names = append(names, n)
+			s.names = append(s.names, n)
 		}
-		sort.Strings(names)
+		sort.Strings(s.names)
 	}
 
-	rows := make([]Row, 0, len(names))
-	for _, name := range names {
+	for _, name := range s.names {
 		entry := cfg.Stores[name]
 		results := storeops.GetStatus(root, name, entry)
 		state := aggregate(results)
@@ -67,21 +101,49 @@ func (s *Stores) Refresh(root string, cfg *config.Config, freshMarks map[string]
 			summary = plural(len(targets), "target", "targets")
 		}
 
-		row := Row{Name: name, Summary: summary, State: state}
-		if old, ok := prev[name]; ok && old != state {
+		d := storeData{state: state, summary: summary}
+		if old, ok := prev[name]; ok && old.state != state {
 			freshMarks[name] = now
 		}
 		if ts, ok := freshMarks[name]; ok {
 			age := now.Sub(ts)
-			row.Fresh = decay(age, 2*time.Second)
-			if row.Fresh <= 0 {
+			d.fresh = decay(age, 2*time.Second)
+			if d.fresh <= 0 {
 				delete(freshMarks, name)
 			}
 		}
-		rows = append(rows, row)
+		s.data[name] = d
 	}
-	s.all = rows
+
+	// Drop expansion state for groups that no longer have any descendants.
+	if len(s.expanded) > 0 {
+		live := liveGroups(s.names)
+		for g := range s.expanded {
+			if !live[g] {
+				delete(s.expanded, g)
+			}
+		}
+	}
+
 	s.rebuild()
+}
+
+// liveGroups returns the set of group paths that currently have at least
+// one store underneath them.
+func liveGroups(names []string) map[string]bool {
+	out := map[string]bool{}
+	for _, n := range names {
+		idx := 0
+		for {
+			i := strings.IndexByte(n[idx:], '/')
+			if i < 0 {
+				break
+			}
+			out[n[:idx+i]] = true
+			idx += i + 1
+		}
+	}
+	return out
 }
 
 // Filter updates the live filter.
@@ -93,21 +155,41 @@ func (s *Stores) Filter(q string) {
 // FilterQuery returns the current filter.
 func (s *Stores) FilterQuery() string { return s.filter }
 
-// Count returns the filtered row count.
+// Count returns the visible row count (groups + stores).
 func (s *Stores) Count() int { return len(s.view) }
 
-// TotalCount returns the unfiltered row count.
-func (s *Stores) TotalCount() int { return len(s.all) }
+// TotalCount returns the unfiltered store count (excludes groups).
+func (s *Stores) TotalCount() int { return len(s.names) }
 
-// Cursor returns the current cursor index within the filtered view.
+// Cursor returns the current cursor index within the view.
 func (s *Stores) Cursor() int { return s.cursor }
 
-// Selected returns the name of the store under the cursor, or "".
+// Selected returns the full name of the row under the cursor (group path
+// or store name), or "".
 func (s *Stores) Selected() string {
-	if s.cursor < 0 || s.cursor >= len(s.view) {
+	r, ok := s.SelectedRow()
+	if !ok {
 		return ""
 	}
-	return s.view[s.cursor].Name
+	return r.Name
+}
+
+// SelectedStore returns the full name only if the cursor sits on a leaf
+// store row. Use this when an action only makes sense for stores.
+func (s *Stores) SelectedStore() string {
+	r, ok := s.SelectedRow()
+	if !ok || r.IsGroup {
+		return ""
+	}
+	return r.Name
+}
+
+// SelectedRow returns the row under the cursor.
+func (s *Stores) SelectedRow() (Row, bool) {
+	if s.cursor < 0 || s.cursor >= len(s.view) {
+		return Row{}, false
+	}
+	return s.view[s.cursor], true
 }
 
 // Up moves the cursor one row toward the top.
@@ -135,8 +217,76 @@ func (s *Stores) Bottom() {
 	}
 }
 
-// Rows returns the visible rows (unbounded). Use Window for a cursor-
-// centered slice bounded by a height budget.
+// Expand opens the group under the cursor. Returns true if anything
+// changed (the cursor was on a collapsed group).
+func (s *Stores) Expand() bool {
+	r, ok := s.SelectedRow()
+	if !ok || !r.IsGroup || r.Expanded {
+		return false
+	}
+	s.expanded[r.Name] = true
+	s.rebuild()
+	return true
+}
+
+// Collapse shuts the group under the cursor (or, if the cursor is on a
+// nested store row, jumps up to its parent group and collapses that).
+// Returns true if anything changed.
+func (s *Stores) Collapse() bool {
+	r, ok := s.SelectedRow()
+	if !ok {
+		return false
+	}
+	if r.IsGroup && r.Expanded {
+		delete(s.expanded, r.Name)
+		s.rebuild()
+		return true
+	}
+	if !r.IsGroup && r.Depth > 0 {
+		// Walk up to the nearest visible parent group.
+		parent := groupParent(r.Name)
+		for parent != "" {
+			if i := s.indexOfGroup(parent); i >= 0 {
+				s.cursor = i
+				return true
+			}
+			parent = groupParent(parent)
+		}
+	}
+	return false
+}
+
+// ToggleExpand flips the expansion state of the group under the cursor.
+// No-op for store rows.
+func (s *Stores) ToggleExpand() bool {
+	r, ok := s.SelectedRow()
+	if !ok || !r.IsGroup {
+		return false
+	}
+	if r.Expanded {
+		delete(s.expanded, r.Name)
+	} else {
+		s.expanded[r.Name] = true
+	}
+	s.rebuild()
+	return true
+}
+
+// ExpandAll opens every group. Used by the palette command and tests.
+func (s *Stores) ExpandAll() {
+	for _, g := range allGroups(s.names) {
+		s.expanded[g] = true
+	}
+	s.rebuild()
+}
+
+// CollapseAll closes every group.
+func (s *Stores) CollapseAll() {
+	s.expanded = map[string]bool{}
+	s.rebuild()
+}
+
+// Rows returns the visible rows.
 func (s *Stores) Rows() []Row { return s.view }
 
 // Window returns the slice of rows that should be visible given the
@@ -165,8 +315,8 @@ func (s *Stores) Window(height int) (visible []Row, topElided, bottomElided int)
 // Summary returns "N linked  M missing  ..." for the rule above the list.
 func (s *Stores) Summary() string {
 	counts := map[State]int{}
-	for _, r := range s.all {
-		counts[r.State]++
+	for _, name := range s.names {
+		counts[s.data[name].state]++
 	}
 	var parts []string
 	for _, st := range []State{StateLinked, StatePartial, StateMissing, StateConflict, StateBroken, StateSkipped} {
@@ -182,17 +332,55 @@ func (s *Stores) Summary() string {
 
 // HeaderLine returns "N stores" or "N of M stores" when a filter is active.
 func (s *Stores) HeaderLine() string {
+	total := len(s.names)
 	if s.filter == "" {
-		return plural(len(s.all), "store", "stores")
+		return plural(total, "store", "stores")
 	}
-	return plural(len(s.view), "match", "matches") + " of " + plural(len(s.all), "store", "stores")
+	matches := 0
+	for _, r := range s.view {
+		if !r.IsGroup {
+			matches++
+		}
+	}
+	return plural(matches, "match", "matches") + " of " + plural(total, "store", "stores")
+}
+
+// indexOfGroup returns the view index of the given group path, or -1.
+func (s *Stores) indexOfGroup(path string) int {
+	for i, r := range s.view {
+		if r.IsGroup && r.Name == path {
+			return i
+		}
+	}
+	return -1
+}
+
+// groupParent returns the parent group path of a slash-named row, or "".
+func groupParent(name string) string {
+	idx := strings.LastIndex(name, "/")
+	if idx < 0 {
+		return ""
+	}
+	return name[:idx]
+}
+
+// allGroups returns every group path that exists across the given store
+// names.
+func allGroups(names []string) []string {
+	live := liveGroups(names)
+	out := make([]string, 0, len(live))
+	for g := range live {
+		out = append(out, g)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // RenderRow renders one row of the store ledger at the given content width.
 // `selected` is true for the row under the cursor; `reveal` is the 0..1
 // fade-in opacity used during the initial staggered reveal.
 func RenderRow(r Row, width int, selected bool, reveal float64) string {
-	// Spark slot (fresh-change flourish).
+	// Spark slot (fresh-change flourish, leaf rows only).
 	spark := "  "
 	if r.Fresh > 0 {
 		c := Mix(ColorFaint, ColorEmber, r.Fresh)
@@ -207,19 +395,36 @@ func RenderRow(r Row, width int, selected bool, reveal float64) string {
 		nameStyle = StyleSelected
 	}
 
+	// Per-depth indent. Depth 0 means the row sits at the top level.
+	indent := strings.Repeat("  ", r.Depth)
+
+	// Group glyph: "+" collapsed, "−" expanded. Non-group rows leave the
+	// slot blank so leaf names align with their group's title text.
+	groupGlyph := "  "
+	if r.IsGroup {
+		if r.Expanded {
+			groupGlyph = StyleDim.Render("−") + " "
+		} else {
+			groupGlyph = StyleEmber.Render("+") + " "
+		}
+	}
+
 	// State badge (right).
 	stateGlyph := lipgloss.NewStyle().Foreground(r.State.Color()).Render(r.State.Glyph())
 	stateLabel := lipgloss.NewStyle().Foreground(r.State.Color()).Render(r.State.Label())
 	rightCol := stateGlyph + "  " + stateLabel
 
-	// Name + summary left side.
-	leftPrefixWidth := 4 // spark(2) + marker(2)
+	// Compose left side.
+	leftPrefixWidth := 4 + lipgloss.Width(indent) + lipgloss.Width(groupGlyph)
 	nameWidth := 12
-	name := nameStyle.Render(padName(r.Name, nameWidth))
+	display := r.Display
+	if display == "" {
+		display = r.Name
+	}
+	name := nameStyle.Render(padName(display, nameWidth))
 	summary := StyleDim.Render(Clip(r.Summary, max(10, width-leftPrefixWidth-nameWidth-3-lipgloss.Width(rightCol))))
 
-	// Assemble with fill between summary and right column.
-	line := spark + marker + name + " " + summary
+	line := spark + marker + indent + groupGlyph + name + " " + summary
 	used := lipgloss.Width(line)
 	rightW := lipgloss.Width(rightCol)
 	gap := width - used - rightW
@@ -283,6 +488,37 @@ func aggregate(results []storeops.StatusInfo) State {
 	return StatePartial
 }
 
+// aggregateStates rolls up a slice of leaf states into a single group
+// state. Conflict/error wins; otherwise all-linked, all-missing, or
+// partial.
+func aggregateStates(states []State) State {
+	if len(states) == 0 {
+		return StateSkipped
+	}
+	for _, st := range states {
+		if st == StateConflict || st == StateBroken {
+			return StateConflict
+		}
+	}
+	allLinked := true
+	allMissing := true
+	for _, st := range states {
+		if st != StateLinked {
+			allLinked = false
+		}
+		if st != StateMissing && st != StateSkipped {
+			allMissing = false
+		}
+	}
+	if allLinked {
+		return StateLinked
+	}
+	if allMissing {
+		return StateMissing
+	}
+	return StatePartial
+}
+
 func plural(n int, singular, pluralForm string) string {
 	if n == 1 {
 		return "1 " + singular
@@ -314,14 +550,34 @@ func itoa(n int) string {
 }
 
 func (s *Stores) rebuild() {
-	if s.filter == "" {
-		s.view = append(s.view[:0], s.all...)
+	prevKey := ""
+	if r, ok := s.SelectedRow(); ok {
+		prevKey = rowKey(r)
+	}
+
+	if s.filter != "" {
+		s.view = s.flattenedFilteredRows()
 	} else {
-		q := strings.ToLower(s.filter)
-		s.view = s.view[:0]
-		for _, r := range s.all {
-			if strings.Contains(strings.ToLower(r.Name), q) {
-				s.view = append(s.view, r)
+		s.view = s.treeRows()
+	}
+
+	if prevKey != "" {
+		for i, r := range s.view {
+			if rowKey(r) == prevKey {
+				s.cursor = i
+				return
+			}
+		}
+		// If we collapsed the parent of a previously-selected store,
+		// land the cursor on that parent group.
+		if strings.HasPrefix(prevKey, "s:") {
+			ancestor := groupParent(prevKey[len("s:"):])
+			for ancestor != "" {
+				if idx := s.indexOfGroup(ancestor); idx >= 0 {
+					s.cursor = idx
+					return
+				}
+				ancestor = groupParent(ancestor)
 			}
 		}
 	}
@@ -331,6 +587,141 @@ func (s *Stores) rebuild() {
 	if s.cursor < 0 {
 		s.cursor = 0
 	}
+}
+
+func rowKey(r Row) string {
+	if r.IsGroup {
+		return "g:" + r.Name
+	}
+	return "s:" + r.Name
+}
+
+// flattenedFilteredRows lists every store whose name matches the filter,
+// at depth 0, with no group rows. Filter mode is meant to be a flat
+// finder, not a hierarchical browser.
+func (s *Stores) flattenedFilteredRows() []Row {
+	q := strings.ToLower(s.filter)
+	out := make([]Row, 0, len(s.names))
+	for _, name := range s.names {
+		if !strings.Contains(strings.ToLower(name), q) {
+			continue
+		}
+		d := s.data[name]
+		out = append(out, Row{
+			Name:    name,
+			Display: name,
+			Summary: d.summary,
+			State:   d.state,
+			Fresh:   d.fresh,
+		})
+	}
+	return out
+}
+
+// tnode is an ephemeral tree built from the sorted name list to drive
+// rendering. It is not retained between rebuilds.
+type tnode struct {
+	seg       string
+	path      string
+	storeName string // non-empty when this node is also a leaf store
+	store     *storeData
+	children  []*tnode
+}
+
+func (s *Stores) treeRows() []Row {
+	root := &tnode{}
+	for _, name := range s.names {
+		parts := strings.Split(name, "/")
+		cur := root
+		for i, p := range parts {
+			child := findChild(cur, p)
+			if child == nil {
+				fullPath := p
+				if cur.path != "" {
+					fullPath = cur.path + "/" + p
+				}
+				child = &tnode{seg: p, path: fullPath}
+				cur.children = append(cur.children, child)
+			}
+			if i == len(parts)-1 {
+				d := s.data[name]
+				child.storeName = name
+				child.store = &d
+			}
+			cur = child
+		}
+	}
+
+	var out []Row
+	var walk func(n *tnode, depth int)
+	walk = func(n *tnode, depth int) {
+		for _, c := range n.children {
+			isPureGroup := c.store == nil && len(c.children) > 0
+			if isPureGroup {
+				state, leaves := aggregateGroup(c)
+				expanded := s.expanded[c.path]
+				out = append(out, Row{
+					Name:            c.path,
+					Display:         c.seg,
+					Depth:           depth,
+					IsGroup:         true,
+					Expanded:        expanded,
+					DescendantCount: leaves,
+					Summary:         plural(leaves, "store", "stores"),
+					State:           state,
+				})
+				if expanded {
+					walk(c, depth+1)
+				}
+				continue
+			}
+			// Leaf store row, or store-with-children (rare collision).
+			if c.store != nil {
+				display := c.seg
+				if depth == 0 {
+					display = c.storeName
+				}
+				out = append(out, Row{
+					Name:    c.storeName,
+					Display: display,
+					Depth:   depth,
+					Summary: c.store.summary,
+					State:   c.store.state,
+					Fresh:   c.store.fresh,
+				})
+			}
+			if len(c.children) > 0 {
+				// Collision case: show descendants flat under the leaf.
+				walk(c, depth+1)
+			}
+		}
+	}
+	walk(root, 0)
+	return out
+}
+
+func findChild(n *tnode, seg string) *tnode {
+	for _, c := range n.children {
+		if c.seg == seg {
+			return c
+		}
+	}
+	return nil
+}
+
+func aggregateGroup(n *tnode) (State, int) {
+	var states []State
+	var walk func(*tnode)
+	walk = func(t *tnode) {
+		if t.store != nil {
+			states = append(states, t.store.state)
+		}
+		for _, c := range t.children {
+			walk(c)
+		}
+	}
+	walk(n)
+	return aggregateStates(states), len(states)
 }
 
 // dim crossfades a rendered line toward the faint color at intensity

--- a/internal/tui/stores_test.go
+++ b/internal/tui/stores_test.go
@@ -2,16 +2,34 @@ package tui
 
 import "testing"
 
-func TestStoresFilterAndCursor(t *testing.T) {
-	s := NewStores()
-	// Inject rows by hand; Refresh needs a full config + filesystem.
-	s.all = []Row{
-		{Name: "nvim", State: StateLinked},
-		{Name: "shells", State: StatePartial},
-		{Name: "git", State: StateLinked},
-		{Name: "tmux", State: StateMissing},
+// seed populates s with synthetic store data, bypassing the real Refresh
+// path which needs a config + filesystem.
+func seed(s *Stores, items map[string]State) {
+	s.data = map[string]storeData{}
+	s.names = s.names[:0]
+	for name, st := range items {
+		s.data[name] = storeData{state: st, summary: name}
+		s.names = append(s.names, name)
+	}
+	// keep names sorted to match Refresh's contract.
+	for i := 0; i < len(s.names); i++ {
+		for j := i + 1; j < len(s.names); j++ {
+			if s.names[j] < s.names[i] {
+				s.names[i], s.names[j] = s.names[j], s.names[i]
+			}
+		}
 	}
 	s.rebuild()
+}
+
+func TestStoresFilterAndCursor(t *testing.T) {
+	s := NewStores()
+	seed(s, map[string]State{
+		"nvim":   StateLinked,
+		"shells": StatePartial,
+		"git":    StateLinked,
+		"tmux":   StateMissing,
+	})
 
 	if s.Count() != 4 {
 		t.Fatalf("expected 4 rows, got %d", s.Count())
@@ -37,6 +55,126 @@ func TestStoresFilterAndCursor(t *testing.T) {
 	s.Filter("")
 	if s.Count() != 4 {
 		t.Errorf("cleared filter should restore all rows; got %d", s.Count())
+	}
+}
+
+func TestTreeCollapsedByDefault(t *testing.T) {
+	s := NewStores()
+	seed(s, map[string]State{
+		"desktop/hyprland": StateLinked,
+		"desktop/waybar":   StateLinked,
+		"editors/neovim":   StateLinked,
+		"kmonad":           StateLinked,
+	})
+	// Expect 3 visible rows: two collapsed groups + 1 leaf store.
+	if s.Count() != 3 {
+		t.Fatalf("collapsed view count = %d, want 3", s.Count())
+	}
+	rows := s.Rows()
+	if !rows[0].IsGroup || rows[0].Name != "desktop" {
+		t.Errorf("row 0 = %+v, want desktop group", rows[0])
+	}
+	if !rows[1].IsGroup || rows[1].Name != "editors" {
+		t.Errorf("row 1 = %+v, want editors group", rows[1])
+	}
+	if rows[2].IsGroup || rows[2].Name != "kmonad" {
+		t.Errorf("row 2 = %+v, want kmonad leaf", rows[2])
+	}
+	if rows[0].DescendantCount != 2 {
+		t.Errorf("desktop group count = %d, want 2", rows[0].DescendantCount)
+	}
+}
+
+func TestTreeExpandShowsChildren(t *testing.T) {
+	s := NewStores()
+	seed(s, map[string]State{
+		"desktop/hyprland": StateLinked,
+		"desktop/waybar":   StateLinked,
+		"kmonad":           StateLinked,
+	})
+	// Cursor is on row 0 — desktop group.
+	if !s.Expand() {
+		t.Fatal("Expand() returned false on collapsed group")
+	}
+	// Now: desktop, hyprland, waybar, kmonad — 4 rows.
+	if s.Count() != 4 {
+		t.Fatalf("after expand, count = %d, want 4", s.Count())
+	}
+	rows := s.Rows()
+	if rows[1].IsGroup || rows[1].Display != "hyprland" || rows[1].Depth != 1 {
+		t.Errorf("row 1 = %+v, want depth-1 leaf hyprland", rows[1])
+	}
+	if rows[1].Name != "desktop/hyprland" {
+		t.Errorf("row 1 Name = %q, want desktop/hyprland", rows[1].Name)
+	}
+}
+
+func TestTreeCollapseFromChildJumpsToParent(t *testing.T) {
+	s := NewStores()
+	seed(s, map[string]State{
+		"desktop/hyprland": StateLinked,
+		"desktop/waybar":   StateLinked,
+	})
+	s.Expand() // open desktop
+	s.Down()   // move onto hyprland
+	r, _ := s.SelectedRow()
+	if r.IsGroup {
+		t.Fatalf("expected leaf cursor, got %+v", r)
+	}
+	if !s.Collapse() {
+		t.Fatal("Collapse() from child should jump to parent")
+	}
+	r, _ = s.SelectedRow()
+	if !r.IsGroup || r.Name != "desktop" {
+		t.Errorf("after Collapse, row = %+v, want desktop group", r)
+	}
+}
+
+func TestTreeAggregatesGroupState(t *testing.T) {
+	s := NewStores()
+	seed(s, map[string]State{
+		"desktop/hyprland": StateLinked,
+		"desktop/waybar":   StateMissing,
+	})
+	rows := s.Rows()
+	if rows[0].State != StatePartial {
+		t.Errorf("desktop group state = %v, want partial (linked + missing)", rows[0].State)
+	}
+}
+
+func TestFilterFlattensTree(t *testing.T) {
+	s := NewStores()
+	seed(s, map[string]State{
+		"desktop/hyprland": StateLinked,
+		"desktop/waybar":   StateLinked,
+		"kmonad":           StateLinked,
+	})
+	s.Filter("way")
+	if s.Count() != 1 {
+		t.Fatalf("filter view count = %d, want 1", s.Count())
+	}
+	r, _ := s.SelectedRow()
+	if r.IsGroup || r.Name != "desktop/waybar" {
+		t.Errorf("filter row = %+v, want desktop/waybar leaf", r)
+	}
+	// Filter mode shows the full slash path, not just the leaf.
+	if r.Display != "desktop/waybar" {
+		t.Errorf("filter row Display = %q, want full path", r.Display)
+	}
+}
+
+func TestSelectedStoreIgnoresGroups(t *testing.T) {
+	s := NewStores()
+	seed(s, map[string]State{
+		"desktop/hyprland": StateLinked,
+	})
+	if got := s.SelectedStore(); got != "" {
+		t.Errorf("cursor on group: SelectedStore = %q, want empty", got)
+	}
+	s.Expand()
+	s.Down()
+	if got := s.SelectedStore(); got != "desktop/hyprland" {
+		t.Errorf("cursor on leaf: SelectedStore = %q, want desktop/hyprland", got)
 	}
 }
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -265,6 +265,7 @@ func (a *App) handleKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 func (a *App) handleListKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
+	row, hasRow := a.stores.SelectedRow()
 	switch {
 	case key.Matches(k, a.keys.Up):
 		a.stores.Up()
@@ -279,24 +280,60 @@ func (a *App) handleListKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 		a.stores.Bottom()
 		a.flashDetail()
 	case key.Matches(k, a.keys.Enter):
-		if name := a.stores.Selected(); name != "" {
-			a.overlay = OverlayActions
-			a.actions = NewActions(name)
+		if !hasRow {
+			return a, nil
+		}
+		if row.IsGroup {
+			a.stores.ToggleExpand()
+			a.flashDetail()
+			return a, nil
+		}
+		a.overlay = OverlayActions
+		a.actions = NewActions(row.Name)
+	case key.Matches(k, a.keys.Expand):
+		if !hasRow {
+			return a, nil
+		}
+		if row.IsGroup {
+			if !row.Expanded {
+				a.stores.Expand()
+			} else {
+				a.stores.Down()
+			}
+			a.flashDetail()
+			return a, nil
+		}
+		// Leaf: l opens the actions menu, mirroring enter.
+		a.overlay = OverlayActions
+		a.actions = NewActions(row.Name)
+	case key.Matches(k, a.keys.Collapse):
+		if a.stores.Collapse() {
+			a.flashDetail()
 		}
 	case key.Matches(k, a.keys.Space):
+		if hasRow && row.IsGroup {
+			a.stores.ToggleExpand()
+			a.flashDetail()
+			return a, nil
+		}
 		return a, a.trackOp(a.quickToggle())
 	case key.Matches(k, a.keys.Diff):
-		if name := a.stores.Selected(); name != "" {
+		if name := a.stores.SelectedStore(); name != "" {
 			return a, a.trackOp(CmdDiff(a.root, name, a.cfg.Stores[name]))
 		}
 	case key.Matches(k, a.keys.ApplyAll):
 		return a, a.trackOp(CmdApplyAll(a.root, a.cfg))
 	case key.Matches(k, a.keys.Remove):
-		if name := a.stores.Selected(); name != "" {
+		if name := a.stores.SelectedStore(); name != "" {
 			a.openRemoveConfirm(name)
 		}
 	case key.Matches(k, a.keys.Back):
-		// esc clears filter if active
+		// h doubles as "collapse / jump to parent" when there's somewhere
+		// to go in the tree. Otherwise it (or esc) clears an active filter.
+		if a.stores.Collapse() {
+			a.flashDetail()
+			return a, nil
+		}
 		if a.stores.FilterQuery() != "" {
 			a.stores.Filter("")
 		}
@@ -310,7 +347,7 @@ func (a *App) handleListKey(k tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 func (a *App) quickToggle() tea.Cmd {
-	name := a.stores.Selected()
+	name := a.stores.SelectedStore()
 	if name == "" {
 		return nil
 	}
@@ -932,9 +969,23 @@ func (a *App) renderMain() string {
 
 	b.WriteString("\n")
 
-	// Detail section
-	selName := a.stores.Selected()
-	if selName != "" {
+	// Detail section. The detail pane only makes sense for leaf stores;
+	// when the cursor sits on a group row we render an aggregate header
+	// without the per-target ledger.
+	selRow, hasSel := a.stores.SelectedRow()
+	if hasSel && selRow.IsGroup {
+		flash := decay(now.Sub(a.detailFlashAt), 200*time.Millisecond)
+		ruleColor := selRow.State.Color()
+		if flash > 0 {
+			ruleColor = Mix(selRow.State.Color(), ColorEmber, flash)
+		}
+		title := selRow.Name + "/"
+		right := plural(selRow.DescendantCount, "store", "stores") + "  " + selRow.State.Label()
+		b.WriteString(Rule(width-4, title, right, ruleColor))
+		b.WriteString("\n\n  " + StyleDim.Render("press l or enter to expand"))
+		b.WriteString("\n")
+	} else if hasSel {
+		selName := selRow.Name
 		entry, ok := a.cfg.Stores[selName]
 		if ok {
 			results := storeops.GetStatus(a.root, selName, entry)


### PR DESCRIPTION
## What this does

Once a dotfiles repo has more than a handful of stores, the flat
`config.yaml` starts to feel like a wall. This PR teaches `store` to
group stores in YAML and to render those groups as a collapsible tree
in the TUI, so you can scan the top of the file at a glance and drill
in only where you need to.

## How it ships

**Nested groups in `config.yaml`.** A YAML map is treated as a store
entry when it has any of `target`, `targets`, `files`, `patterns`,
`ignore`, `hooks`, or `when`. Otherwise it's a group containing more
stores. Names get joined with `/`, so:

```yaml
stores:
  desktop:
    hyprland:
      target: "~/.config/hypr"
    waybar:
      target: "~/.config/waybar"
  editors:
    neovim:
      target: "~/.config/nvim"
  kmonad:
    target: "~/.config/kmonad"
```

defines four stores: `desktop/hyprland`, `desktop/waybar`,
`editors/neovim`, `kmonad`. The on-disk paths are unchanged.

Internal representation stays as a flat `map[string]StoreEntry` keyed
by the joined slash path, so nothing else in the codebase had to move.
Old flat configs still load unchanged. Save defaults to nested form. If
a name like `shells` is also the prefix of another like `shells/fish`,
the file falls back to flat slash keys for those entries so both stay
addressable.

**Tree view in the TUI.** When stores share a slash-prefix, the ledger
collapses them under a group header. `+` is collapsed, `−` is open. The
group row aggregates state (worst child wins) and shows the descendant
count.

Keys:

- `enter` and `space` toggle a group's expand state, or behave as
  before on a leaf row.
- `l` / `→` expands a collapsed group, moves into an open one, or
  opens the action menu on a leaf.
- `h` / `←` collapses an open group, or jumps from a child row up to
  its parent. Falls back to clearing an active filter when there is
  nowhere to collapse to.
- Filter mode flattens matches across all groups so a search hits
  every store regardless of where it lives.

`Stores` keeps a persistent expanded map across refreshes so config
reloads don't fold everything back up. The cursor sticks to its row by
identity through rebuilds and falls back to the parent group when its
store row disappears under a collapse.

## Tests

- New config tests cover nested-only, flat-only, and mixed input,
  round-trip preservation, and the prefix-collision fallback.
- New TUI tests cover the collapsed-by-default invariant, expand
  reveals children, collapse-from-child jumps to parent, group state
  aggregation, filter flattens the tree, and `SelectedStore` ignores
  groups.
- Updated `TestVimMovementNotOverloaded` and `TestKeymapNoCollisions`
  for the new `Expand` / `Collapse` bindings.
- Smoke-tested against my real `~/dotfiles/.store/config.yaml` (16
  stores, all linked) and confirmed a round-trip Save produces the
  expected nested layout.

`go test ./...` and `go vet ./...` are clean.

## Test plan

- [x] All Go tests pass
- [x] `go vet ./...` clean
- [x] Existing flat-key configs load unchanged
- [x] Nested configs load and round-trip
- [x] Prefix collisions (`shells` and `shells/fish`) fall back to flat
- [x] Collapsed-by-default in the tree view
- [x] Expand / collapse keys behave correctly on group and leaf rows

## Release

Bumps to 2.5.0 in CHANGELOG.