### PR TITLE
fix: only treat known store template forms as templates (#58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to `store` are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.1] - 2026-04-27
+
+### Fixed
+
+- **Files with literal `{{ ... }}` content no longer fail rendering.** Until
+  now, `store` treated any file containing `{{` as a Go template and tried
+  to render it, which broke markdown and config files that include
+  GitHub Actions expressions, Helm charts, Jinja examples, or any other
+  literal template-style syntax. Detection is now scoped to the forms
+  `store` actually understands (`{{ secret "..." }}`, `{{ env "..." }}`,
+  and the `.Hostname` / `.OS` / `.Arch` / `.Distro` / `.Shell` / `.Vars`
+  data fields). Anything else is symlinked verbatim. Reported in #58.
+
 ## [2.5.0] - 2026-04-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -439,6 +439,8 @@ How it works:
 
 Files in a store can contain Go `text/template` expressions. When `store` links or restores a store, it renders these templates into a local staging directory and symlinks the rendered output. Files without template expressions are symlinked directly.
 
+A file is treated as a template only when it references one of the names store knows about: the `secret` or `env` function, or one of the `.Hostname` / `.OS` / `.Arch` / `.Distro` / `.Shell` / `.Vars` data fields. Files that contain unrelated `{{ ... }}` content (GitHub Actions expressions, Helm charts, Jinja or Handlebars examples in docs, etc.) are passed through verbatim.
+
 ### Template functions
 
 | Expression                 | Description                                            |

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -25,7 +25,16 @@ type TemplateData struct {
 }
 
 var secretPattern = regexp.MustCompile(`\{\{\s*secret\s+"([^"]+)"\s*\}\}`)
-var templatePattern = regexp.MustCompile(`\{\{`)
+
+// templatePattern matches only the template forms store actually supports:
+// the `secret`/`env` function calls and the `.Hostname`/`.OS`/`.Arch`/`.Distro`
+// /`.Shell`/`.Vars` data references (including the `index .Vars "..."` form).
+// Files that contain unrelated `{{ ... }}` content — GitHub Actions
+// expressions, Helm charts, Jinja examples in docs — are left as plain text
+// and symlinked verbatim instead of being mis-parsed as Go templates.
+var templatePattern = regexp.MustCompile(
+	`\{\{[^{}]*?(?:\bsecret\s+"|\benv\s+"|\.(?:Hostname|OS|Arch|Distro|Shell|Vars)\b)`,
+)
 var varDotPattern = regexp.MustCompile(`\{\{[^{}]*?\.Vars\.([A-Za-z_][A-Za-z0-9_]*)`)
 var varIndexPattern = regexp.MustCompile(`\{\{[^{}]*?index\s+\.Vars\s+"([^"]+)"`)
 
@@ -36,7 +45,10 @@ func HasSecrets(content []byte) bool {
 	return secretPattern.Match(content)
 }
 
-// HasTemplates checks if file content contains any {{ ... }} template syntax.
+// HasTemplates reports whether content contains any template form that store
+// is responsible for rendering. Unrelated `{{ ... }}` content (e.g. literal
+// GitHub Actions or Helm syntax in a markdown file) is intentionally not
+// treated as a template.
 func HasTemplates(content []byte) bool {
 	return templatePattern.Match(content)
 }

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -35,6 +35,55 @@ func TestHasSecrets(t *testing.T) {
 	}
 }
 
+func TestHasTemplates(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		// Recognised store template forms.
+		{name: "secret call", content: `{{ secret "token" }}`, want: true},
+		{name: "secret call tight", content: `{{secret "token"}}`, want: true},
+		{name: "env call", content: `{{ env "HOME" }}`, want: true},
+		{name: "hostname", content: `host={{ .Hostname }}`, want: true},
+		{name: "os", content: `{{ .OS }}`, want: true},
+		{name: "arch", content: `{{ .Arch }}`, want: true},
+		{name: "distro", content: `{{ .Distro }}`, want: true},
+		{name: "shell", content: `{{ .Shell }}`, want: true},
+		{name: "vars dot", content: `editor={{ .Vars.editor }}`, want: true},
+		{name: "vars dot pipeline", content: `{{ .Vars.name | upper }}`, want: true},
+		{name: "vars index", content: `{{ index .Vars "my-key" }}`, want: true},
+		{name: "trim markers", content: `{{- .Hostname -}}`, want: true},
+		{name: "control flow with .OS", content: `{{if eq .OS "linux"}}foo{{end}}`, want: true},
+		{name: "with .Vars block", content: `{{with .Vars}}{{.editor}}{{end}}`, want: true},
+
+		// Literal `{{ ... }}` content from other tools — must NOT be treated
+		// as a store template. These are the regressions reported in #58.
+		{name: "github actions secrets", content: `github_token: ${{ secrets.GITHUB_TOKEN }}`, want: false},
+		{name: "github actions inputs", content: `name: ${{ inputs.name }}`, want: false},
+		{name: "helm values", content: `replicas: {{ .Values.replicaCount }}`, want: false},
+		{name: "helm release", content: `name: {{ .Release.Name }}`, want: false},
+		{name: "jinja variable", content: `Hello {{ name }}`, want: false},
+		{name: "handlebars", content: `{{firstName}} {{lastName}}`, want: false},
+		{name: "literal docs", content: "Use `{{ ... }}` for templates.", want: false},
+		{name: "unbalanced opener", content: `prefix {{ no closer here`, want: false},
+		{name: "vars-like prefix", content: `{{ .Variables.foo }}`, want: false},
+		{name: "os-like prefix", content: `{{ .OSDetails.kernel }}`, want: false},
+
+		// Plain content.
+		{name: "plain text", content: `hello world`, want: false},
+		{name: "empty", content: ``, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HasTemplates([]byte(tt.content)); got != tt.want {
+				t.Fatalf("HasTemplates(%q) = %v, want %v", tt.content, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsBinary(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -397,6 +446,20 @@ func TestPrepareStaging(t *testing.T) {
 			},
 			secrets: map[string]string{},
 			wantErr: `missing secret: missing`,
+		},
+		{
+			name: "literal github actions syntax is symlinked, not rendered",
+			setup: func(t *testing.T, sourceDir, stagingDir string) {
+				writeTestFile(t, filepath.Join(sourceDir, "workflow.md"),
+					"Example:\n\n    github_token: ${{ secrets.GITHUB_TOKEN }}\n")
+			},
+			secrets: map[string]string{},
+			want:    false,
+			assertion: func(t *testing.T, sourceDir, stagingDir string) {
+				assertSymlinkTarget(t,
+					filepath.Join(stagingDir, "workflow.md"),
+					filepath.Join(sourceDir, "workflow.md"))
+			},
 		},
 		{
 			name: "binary files with template-looking bytes are symlinked, not rendered",


### PR DESCRIPTION
## The problem

Reported in #58: any file containing `{{` was treated as a Go template, so markdown and config files that include literal template syntax from other ecosystems failed to render. The example from the issue:

```yaml
github_token: ${{ secrets.GITHUB_TOKEN }}
```

would crash `store apply` with `template: :N: function "secrets" not defined`, even though the file was meant to be linked as-is. The same blocked Helm charts, Jinja examples, and any documentation that quoted `{{ ... }}` verbatim.

## The fix

Detection is now scoped to the forms `store` actually renders. A file is treated as a template only when it references one of:

- `{{ secret "..." }}` or `{{ env "..." }}`
- `{{ .Hostname }}` / `{{ .OS }}` / `{{ .Arch }}` / `{{ .Distro }}` / `{{ .Shell }}`
- `{{ .Vars.key }}` or `{{ index .Vars "key" }}`

Anything else (`${{ secrets.GITHUB_TOKEN }}`, `{{ .Values.replicas }}`, `{{ name }}`, etc.) is symlinked verbatim. This is also a strict improvement over the old heuristic: even files with malformed template-shaped content now pass through cleanly instead of failing the parser.

The change is one regex in `internal/render/render.go`. Existing template forms continue to render unchanged.

## Tests

Added `TestHasTemplates` covering the scenarios from the issue (GitHub Actions, Helm, Jinja, Handlebars, literal docs) plus the lookalike prefixes that the regex needs to reject (`.Variables`, `.OSDetails`). Added a `PrepareStaging` case that uses the exact repro from the issue and verifies the file is symlinked rather than rendered. Full suite (`go test ./...`) and `go vet ./...` both clean.

## Docs

README's Templates & Secrets section now states the scope explicitly so future readers see what does and does not trigger rendering. CHANGELOG entry added under 2.5.1.

Closes #58.