### PR TITLE
feat: per-target when: clauses (#61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,57 @@ All notable changes to `store` are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.0] - 2026-05-01
+
+### Added
+
+- **Per-target `when:` clauses.** A `when:` block can now sit inside a
+  `targets[]` entry, scoped to that one target rather than the whole
+  store. The use case is one repo directory that wants to land at
+  different paths per platform: helix lives at `~/.config/helix` on
+  Linux and `~/AppData/Roaming/helix` on Windows, lazygit at
+  `~/.config/lazygit` vs `~/AppData/Local/lazygit`, and so on. Before
+  this you had to either keep two stores in sync or accept dead
+  symlinks pointing at `~/AppData/...` on Linux. Now you write one
+  store with two targets, each filtered to the platform that applies.
+  Targets without a `when:` always apply, and per-target filters
+  compose with the store-level filter (the store-level one runs
+  first; if it rules the store out, none of its targets run).
+  Thanks to @ekmart for proposing this in #61.
+
+- **`target when` in the TUI command palette.** Press `:` and pick
+  `target when` to set or clear a target's filter without leaving the
+  TUI. The prompt accepts space-separated `key=value` pairs like
+  `os=linux,darwin shell=zsh`. Submitting an empty value clears the
+  filter. The store is unlinked and re-linked in place so the symlink
+  state on disk reflects the new filter immediately.
+
+### Changed
+
+- **`store doctor` is platform-aware about target conflicts.** Two
+  stores claiming the same target path are no longer flagged when
+  their `when:` clauses are disjoint, since they never run on the
+  same machine. The check also reports per-target platform skips the
+  same way it already reported store-level ones, so on a Linux box
+  the windows-only target of a multi-target store shows up as an
+  informational `info` issue rather than a missing symlink.
+
+- **TUI detail view shows skipped targets honestly.** A target whose
+  `when:` excludes the current platform now renders as
+  `skipped on this platform` next to its path, in place of the
+  `0/0 missing` it would have shown before. The remove-confirm
+  overlay does the same: skipped targets are listed but tagged so
+  the body matches what `remove` will actually do.
+
+### Fixed
+
+- **TUI no longer drops a per-target `when:` on collapse.** Removing
+  targets in the TUI down to a single remaining one used to migrate
+  the store back to single-target form, which has no slot for a
+  per-target `when:`. The collapse now refuses to run when the
+  remaining target carries a `when:`, so the constraint can't be
+  silently lost on edit.
+
 ## [2.5.1] - 2026-04-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ Rules:
 | `targets[].files`    | No       | Explicit files to link individually for this target |
 | `targets[].patterns` | No       | Glob patterns to match files for this target        |
 | `targets[].ignore`   | No       | Glob patterns to exclude for this target            |
+| `targets[].when`     | No       | Platform filter scoped to this target only          |
 
 ### `hooks` fields
 
@@ -537,6 +538,22 @@ How it works:
 - Commands that operate on the configured set, such as `store apply`, `store diff`, and `store status`, skip non-matching stores.
 - `store doctor` reports skipped stores as informational issues so you can confirm the filter is doing what you expect.
 
+The same `when:` clause is also valid inside a `targets[]` entry, which is the right tool when one repo directory routes to different paths per platform. Helix is the canonical example: its config lives under `~/.config/helix` on Linux and `~/AppData/Roaming/helix` on Windows, and you want exactly one symlink on each machine.
+
+```yaml
+stores:
+  helix:
+    targets:
+      - target: "~/.config/helix"
+        when:
+          os: linux
+      - target: "~/AppData/Roaming/helix"
+        when:
+          os: windows
+```
+
+A target without a `when:` always applies; a non-matching one is skipped on link, unlink, and status. `store doctor` reports skipped targets the same way it reports skipped stores. Per-target and store-level filters compose: if the store-level `when:` excludes the platform, none of its targets run.
+
 ---
 
 ## Ignoring Files
@@ -648,7 +665,9 @@ alongside groups at the same indent.
 
 ### Command palette
 
-Press `:` anywhere to open a fuzzy-match palette over every CLI verb: `apply`, `init`, `import`, `adopt`, `add`, `modify`, `remove`, `remove --all`, `list`, `path`, `rename`, `edit`, `status`, `diff`, `doctor`, `version`, `target {add,remove,modify}`, `secret {set,get,remove,list}`. Pick an entry with `enter`; the palette prompts inline for any required arguments.
+Press `:` anywhere to open a fuzzy-match palette over every CLI verb: `apply`, `init`, `import`, `adopt`, `add`, `modify`, `remove`, `remove --all`, `list`, `path`, `rename`, `edit`, `status`, `diff`, `doctor`, `version`, `target {add,remove,modify,when}`, `secret {set,get,remove,list}`. Pick an entry with `enter`; the palette prompts inline for any required arguments.
+
+`target when` is the editing path for per-target platform filters: pick a store and a target, then type a `key=value` expression like `os=linux,darwin shell=zsh`. Submit an empty value to clear the filter. The store is unlinked and re-linked in place so the symlink reflects the new filter on the current platform.
 
 ### Destructive actions
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	core "github.com/cushycush/store-core/config"
+	"github.com/cushycush/store-core/platform"
 	"gopkg.in/yaml.v3"
 )
 
@@ -44,10 +45,11 @@ func FindRoot() (string, error) {
 
 // TargetEntry represents a single target within a store.
 type TargetEntry struct {
-	Target   string   `yaml:"target,omitempty"`
-	Files    []string `yaml:"files,omitempty"`
-	Patterns []string `yaml:"patterns,omitempty"`
-	Ignore   []string `yaml:"ignore,omitempty"`
+	Target   string      `yaml:"target,omitempty"`
+	Files    []string    `yaml:"files,omitempty"`
+	Patterns []string    `yaml:"patterns,omitempty"`
+	Ignore   []string    `yaml:"ignore,omitempty"`
+	When     *WhenClause `yaml:"when,omitempty"`
 }
 
 // HookEntry defines pre and post shell commands to run around store operations.
@@ -95,7 +97,9 @@ func (e StoreEntry) IsMultiTarget() bool {
 }
 
 // ResolvedTargets normalizes both single-target and multi-target formats
-// into a slice of TargetEntry.
+// into a slice of TargetEntry. Per-target when: clauses are not consulted here;
+// use ApplicableTargets when you only want targets that apply on the current
+// platform.
 func (e StoreEntry) ResolvedTargets() []TargetEntry {
 	if len(e.Targets) > 0 {
 		return e.Targets
@@ -109,6 +113,22 @@ func (e StoreEntry) ResolvedTargets() []TargetEntry {
 		Patterns: e.Patterns,
 		Ignore:   e.Ignore,
 	}}
+}
+
+// ApplicableTargets returns the resolved targets that match the current platform
+// according to each target's when: clause. Targets without a when: clause always
+// apply. The store-level when: is filtered separately at the store level
+// (see filterStoresByPlatform), so this method assumes the store itself is in
+// scope and only narrows by target.
+func (e StoreEntry) ApplicableTargets(info platform.Info) []TargetEntry {
+	all := e.ResolvedTargets()
+	out := make([]TargetEntry, 0, len(all))
+	for _, t := range all {
+		if t.When == nil || t.When.Matches(info) {
+			out = append(out, t)
+		}
+	}
+	return out
 }
 
 // Validate checks that the entry is well-formed.
@@ -153,9 +173,14 @@ func (e *StoreEntry) MigrateToMultiTarget() {
 }
 
 // MigrateToSingleTarget converts back to single-target format if only one target remains.
+// Single-target form has no slot for a per-target when: clause, so a remaining target
+// that carries one stays in multi-target form.
 func (e *StoreEntry) MigrateToSingleTarget() {
 	if len(e.Targets) == 1 {
 		t := e.Targets[0]
+		if t.When != nil {
+			return
+		}
 		e.Target = t.Target
 		e.Files = t.Files
 		e.Patterns = t.Patterns

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -8,6 +8,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/cushycush/store-core/platform"
 )
 
 func TestTargetEntryHasFileMode(t *testing.T) {
@@ -176,6 +178,64 @@ func TestStoreEntryResolvedTargets(t *testing.T) {
 				t.Fatalf("ResolvedTargets() = %#v, want %#v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestStoreEntryApplicableTargets(t *testing.T) {
+	linuxOnly := &WhenClause{OS: Strings{"linux"}}
+	windowsOnly := &WhenClause{OS: Strings{"windows"}}
+	linuxOrDarwin := &WhenClause{OS: Strings{"linux", "darwin"}}
+
+	entry := StoreEntry{Targets: []TargetEntry{
+		{Target: "~/.config/helix", When: linuxOnly},
+		{Target: "~/AppData/Roaming/helix", When: windowsOnly},
+		{Target: "~/.local/share/helix", When: linuxOrDarwin},
+		{Target: "~/.helix"}, // no when: always applies
+	}}
+
+	tests := []struct {
+		name string
+		info platform.Info
+		want []string
+	}{
+		{
+			name: "linux keeps linux-only, linux-or-darwin, and unconstrained",
+			info: platform.Info{OS: "linux"},
+			want: []string{"~/.config/helix", "~/.local/share/helix", "~/.helix"},
+		},
+		{
+			name: "windows keeps only windows-only and unconstrained",
+			info: platform.Info{OS: "windows"},
+			want: []string{"~/AppData/Roaming/helix", "~/.helix"},
+		},
+		{
+			name: "darwin keeps linux-or-darwin and unconstrained",
+			info: platform.Info{OS: "darwin"},
+			want: []string{"~/.local/share/helix", "~/.helix"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := entry.ApplicableTargets(tt.info)
+			gotPaths := make([]string, len(got))
+			for i, te := range got {
+				gotPaths[i] = te.Target
+			}
+			if !reflect.DeepEqual(gotPaths, tt.want) {
+				t.Fatalf("ApplicableTargets(%+v) targets = %v, want %v", tt.info, gotPaths, tt.want)
+			}
+		})
+	}
+}
+
+func TestStoreEntryApplicableTargetsSingleTargetForm(t *testing.T) {
+	// Single-target form has no per-target when:; the store-level when: is filtered
+	// elsewhere, so ApplicableTargets always returns the resolved single target.
+	entry := StoreEntry{Target: "~/.zshrc", When: &WhenClause{OS: Strings{"linux"}}}
+	got := entry.ApplicableTargets(platform.Info{OS: "windows"})
+	if len(got) != 1 || got[0].Target != "~/.zshrc" {
+		t.Fatalf("ApplicableTargets() = %#v, want single ~/.zshrc target", got)
 	}
 }
 
@@ -358,6 +418,21 @@ func TestStoreEntryMigrateToSingleTarget(t *testing.T) {
 				Patterns: nil,
 			},
 		},
+		{
+			name: "remaining target with when stays multi-target",
+			in: StoreEntry{
+				Targets: []TargetEntry{{
+					Target: "~/.config/helix",
+					When:   &WhenClause{OS: Strings{"linux"}},
+				}},
+			},
+			want: StoreEntry{
+				Targets: []TargetEntry{{
+					Target: "~/.config/helix",
+					When:   &WhenClause{OS: Strings{"linux"}},
+				}},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -529,6 +604,12 @@ func TestConfigLoadSaveRoundTrip(t *testing.T) {
 				Targets: []TargetEntry{
 					{Target: "~", Files: []string{".zshrc", ".bashrc"}, Ignore: []string{"*.bak"}},
 					{Target: "~/.config/fish", Patterns: []string{"*.fish"}, Ignore: []string{"scratch/"}},
+				},
+			},
+			"helix": {
+				Targets: []TargetEntry{
+					{Target: "~/.config/helix", When: &WhenClause{OS: Strings{"linux"}}},
+					{Target: "~/AppData/Roaming/helix", When: &WhenClause{OS: Strings{"windows"}}},
 				},
 			},
 		},

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -33,7 +33,7 @@ func Check(root string) []Issue {
 	issues = append(issues, checkOrphanedConfigEntries(root, cfg)...)
 	issues = append(issues, checkUnconfiguredDirectories(root, cfg)...)
 	issues = append(issues, checkBrokenSymlinks(root, cfg)...)
-	issues = append(issues, checkConflictingTargets(cfg)...)
+	issues = append(issues, checkConflictingTargets(cfg, platformInfo)...)
 	issues = append(issues, checkMissingSecrets(root, cfg)...)
 	issues = append(issues, checkEmptyStores(root, cfg)...)
 	issues = append(issues, checkPlatformSkippedStores(cfg, platformInfo)...)
@@ -142,7 +142,7 @@ func checkBrokenSymlinks(root string, cfg *config.Config) []Issue {
 	return issues
 }
 
-func checkConflictingTargets(cfg *config.Config) []Issue {
+func checkConflictingTargets(cfg *config.Config, info platform.Info) []Issue {
 	type claim struct {
 		store  string
 		target string
@@ -153,7 +153,10 @@ func checkConflictingTargets(cfg *config.Config) []Issue {
 
 	for _, name := range sortedStoreNames(cfg) {
 		entry := cfg.Stores[name]
-		for _, targetEntry := range entry.ResolvedTargets() {
+		if entry.When != nil && !entry.When.Matches(info) {
+			continue
+		}
+		for _, targetEntry := range entry.ApplicableTargets(info) {
 			normalized := normalizeTarget(targetEntry.Target)
 			if existing, ok := claimed[normalized]; ok && existing.store != name {
 				issues = append(issues, Issue{
@@ -231,13 +234,23 @@ func checkPlatformSkippedStores(cfg *config.Config, info platform.Info) []Issue 
 	var issues []Issue
 	for _, name := range sortedStoreNames(cfg) {
 		entry := cfg.Stores[name]
-		if entry.When == nil || entry.When.Matches(info) {
+		if entry.When != nil && !entry.When.Matches(info) {
+			issues = append(issues, Issue{
+				Level:   "info",
+				Message: platformSkipMessage(name, entry.When, info),
+			})
 			continue
 		}
-		issues = append(issues, Issue{
-			Level:   "info",
-			Message: platformSkipMessage(name, entry.When, info),
-		})
+		// Store applies on this platform; check for individual targets that don't.
+		for _, te := range entry.ResolvedTargets() {
+			if te.When == nil || te.When.Matches(info) {
+				continue
+			}
+			issues = append(issues, Issue{
+				Level:   "info",
+				Message: platformSkipTargetMessage(name, te, info),
+			})
+		}
 	}
 	return issues
 }
@@ -317,6 +330,14 @@ func platformSkipMessage(name string, when *config.WhenClause, info platform.Inf
 		return fmt.Sprintf("store %q will be skipped on this platform", name)
 	}
 	return fmt.Sprintf("store %q will be skipped on this platform (when: %s=%s, current: %s)", name, field, want, current)
+}
+
+func platformSkipTargetMessage(name string, te config.TargetEntry, info platform.Info) string {
+	field, want, current := firstPlatformMismatch(te.When, info)
+	if field == "" {
+		return fmt.Sprintf("store %q target %q will be skipped on this platform", name, te.Target)
+	}
+	return fmt.Sprintf("store %q target %q will be skipped on this platform (when: %s=%s, current: %s)", name, te.Target, field, want, current)
 }
 
 func firstPlatformMismatch(when *config.WhenClause, info platform.Info) (field, want, current string) {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -159,6 +159,62 @@ func TestCheckPlatformSkippedStore(t *testing.T) {
 	}})
 }
 
+func TestCheckPlatformSkippedTarget(t *testing.T) {
+	root := t.TempDir()
+	targetRoot := t.TempDir()
+	mismatch := platformMismatchOS()
+
+	applicable := filepath.Join(targetRoot, "applies")
+	skipped := filepath.Join(targetRoot, "skipped")
+
+	writeConfig(t, root, map[string]config.StoreEntry{
+		"helix": {Targets: []config.TargetEntry{
+			{Target: applicable, When: &config.WhenClause{OS: config.Strings{runtime.GOOS}}},
+			{Target: skipped, When: &config.WhenClause{OS: config.Strings{mismatch}}},
+		}},
+	})
+	writeFile(t, filepath.Join(root, "helix", "config.toml"), "ok\n")
+	if err := linker.Link(filepath.Join(root, "helix"), applicable); err != nil {
+		t.Fatalf("Link() error = %v", err)
+	}
+
+	issues := Check(root)
+	assertIssues(t, issues, []Issue{{
+		Level:   "info",
+		Message: fmt.Sprintf("store %q target %q will be skipped on this platform (when: os=%s, current: %s)", "helix", skipped, mismatch, runtime.GOOS),
+	}})
+}
+
+func TestCheckConflictingTargetsIgnoresPlatformMismatch(t *testing.T) {
+	// Two stores claim the same path but on different platforms via per-target
+	// when:. They never run together, so this is not a conflict.
+	root := t.TempDir()
+	targetRoot := t.TempDir()
+	shared := filepath.Join(targetRoot, "helix")
+	mismatch := platformMismatchOS()
+
+	writeConfig(t, root, map[string]config.StoreEntry{
+		"helix-here": {Targets: []config.TargetEntry{
+			{Target: shared, When: &config.WhenClause{OS: config.Strings{runtime.GOOS}}},
+		}},
+		"helix-elsewhere": {Targets: []config.TargetEntry{
+			{Target: shared, When: &config.WhenClause{OS: config.Strings{mismatch}}},
+		}},
+	})
+	writeFile(t, filepath.Join(root, "helix-here", "config.toml"), "ok\n")
+	writeFile(t, filepath.Join(root, "helix-elsewhere", "config.toml"), "ok\n")
+	if err := linker.Link(filepath.Join(root, "helix-here"), shared); err != nil {
+		t.Fatalf("Link() error = %v", err)
+	}
+
+	issues := Check(root)
+	for _, issue := range issues {
+		if issue.Level == "error" {
+			t.Fatalf("unexpected conflict error: %#v", issue)
+		}
+	}
+}
+
 func TestCheckCleanState(t *testing.T) {
 	root := t.TempDir()
 	targetRoot := t.TempDir()

--- a/internal/store/conflict.go
+++ b/internal/store/conflict.go
@@ -75,10 +75,11 @@ func CollectTargetConflicts(root string, name string, te config.TargetEntry) ([]
 	return conflicts, nil
 }
 
-// CollectConflicts checks all targets in a store entry for conflicts.
+// CollectConflicts checks all platform-applicable targets in a store entry
+// for conflicts. Targets excluded by their when: clause are not checked.
 func CollectConflicts(root string, name string, entry config.StoreEntry) ([]ConflictInfo, error) {
 	var all []ConflictInfo
-	for _, te := range entry.ResolvedTargets() {
+	for _, te := range entry.ApplicableTargets(detectPlatform()) {
 		conflicts, err := CollectTargetConflicts(root, name, te)
 		if err != nil {
 			return nil, err

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -10,8 +10,13 @@ import (
 	"github.com/cushycush/store/v2/internal/hooks"
 	"github.com/cushycush/store/v2/internal/linker"
 	"github.com/cushycush/store/v2/internal/matcher"
+	"github.com/cushycush/store/v2/internal/platform"
 	"github.com/cushycush/store/v2/internal/render"
 )
+
+// detectPlatform is the platform seam used by per-target when: filtering.
+// Tests override it to exercise platform-specific paths deterministically.
+var detectPlatform = platform.Detect
 
 // needsAutoPromotion checks if the source directory contains files/dirs
 // that match global ignore patterns, requiring promotion from whole-directory
@@ -75,7 +80,7 @@ func printErrors(errors []error) {
 }
 
 func runStoreTargets(root, name string, entry config.StoreEntry, action string, runTarget func(config.TargetEntry) error, failureFmt string) error {
-	targets := entry.ResolvedTargets()
+	targets := entry.ApplicableTargets(detectPlatform())
 	if len(targets) == 0 {
 		return nil
 	}
@@ -199,7 +204,7 @@ func StoreAll(root string, cfg *config.Config) error {
 		if err := Store(root, name, entry); err != nil {
 			errors = append(errors, err)
 		} else {
-			for _, te := range entry.ResolvedTargets() {
+			for _, te := range entry.ApplicableTargets(detectPlatform()) {
 				if shouldUseFileMode(filepath.Join(root, name), te) {
 					fmt.Printf("  %s -> %s (files)\n", name, te.Target)
 				} else {
@@ -229,7 +234,7 @@ func StoreAllWithSecrets(root string, cfg *config.Config, rc *RenderContext) err
 		if err := StoreWithSecrets(root, name, entry, rc); err != nil {
 			errors = append(errors, err)
 		} else {
-			for _, te := range entry.ResolvedTargets() {
+			for _, te := range entry.ApplicableTargets(detectPlatform()) {
 				if shouldUseFileMode(filepath.Join(root, name), te) {
 					fmt.Printf("  %s -> %s (files)\n", name, te.Target)
 				} else {
@@ -376,7 +381,7 @@ func StoreRemoveAll(root string, cfg *config.Config) error {
 		if err := StoreRemove(root, name, entry); err != nil {
 			errors = append(errors, err)
 		} else {
-			for _, te := range entry.ResolvedTargets() {
+			for _, te := range entry.ApplicableTargets(detectPlatform()) {
 				fmt.Printf("  removed %s (%s)\n", name, te.Target)
 			}
 		}
@@ -402,13 +407,18 @@ type StatusInfo struct {
 
 // GetStatus checks the symlink status of a single store (all targets).
 // For file-mode targets, it returns one StatusInfo per matched file.
+// Targets whose when: clause excludes the current platform are skipped.
 func GetStatus(root string, name string, entry config.StoreEntry) []StatusInfo {
-	targets := entry.ResolvedTargets()
-	if len(targets) == 0 {
+	resolved := entry.ResolvedTargets()
+	if len(resolved) == 0 {
 		return []StatusInfo{{
 			Name:  name,
 			Error: fmt.Errorf("no target configured -- did you mean `target: \"~\"`?"),
 		}}
+	}
+	targets := entry.ApplicableTargets(detectPlatform())
+	if len(targets) == 0 {
+		return nil
 	}
 
 	source := filepath.Join(root, name)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -7,9 +7,19 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cushycush/store-core/platform"
 	"github.com/cushycush/store/v2/internal/config"
 	"github.com/cushycush/store/v2/internal/linker"
 )
+
+// withPlatform overrides the platform-detection seam for one test and
+// restores the previous value when the test ends.
+func withPlatform(t *testing.T, info platform.Info) {
+	t.Helper()
+	prev := detectPlatform
+	detectPlatform = func() platform.Info { return info }
+	t.Cleanup(func() { detectPlatform = prev })
+}
 
 func createStore(t *testing.T, root, name string, files map[string]string) string {
 	t.Helper()
@@ -918,5 +928,70 @@ func TestGetStatusAll(t *testing.T) {
 	}
 	if shellsInfo.Status != linker.StatusMissing || shellsInfo.Error != nil {
 		t.Fatalf("shells status = %+v, want missing with no error", shellsInfo)
+	}
+}
+
+func TestStorePerTargetWhen(t *testing.T) {
+	root := t.TempDir()
+	createStore(t, root, "helix", map[string]string{"config.toml": "theme = \"base16\""})
+
+	linuxTarget := filepath.Join(root, "linux", "helix")
+	windowsTarget := filepath.Join(root, "windows", "helix")
+
+	entry := config.StoreEntry{Targets: []config.TargetEntry{
+		{Target: linuxTarget, When: &config.WhenClause{OS: config.Strings{"linux"}}},
+		{Target: windowsTarget, When: &config.WhenClause{OS: config.Strings{"windows"}}},
+	}}
+
+	withPlatform(t, platform.Info{OS: "linux"})
+
+	if err := Store(root, "helix", entry); err != nil {
+		t.Fatalf("Store() error = %v", err)
+	}
+
+	assertSymlinkPointsTo(t, linuxTarget, filepath.Join(root, "helix"))
+	assertMissing(t, windowsTarget)
+
+	// GetStatus should also only report the applicable target.
+	status := GetStatus(root, "helix", entry)
+	if len(status) != 1 {
+		t.Fatalf("GetStatus() len = %d, want 1: %+v", len(status), status)
+	}
+	if status[0].Target != linuxTarget {
+		t.Fatalf("GetStatus()[0].Target = %q, want %q", status[0].Target, linuxTarget)
+	}
+	if status[0].Status != linker.StatusLinked {
+		t.Fatalf("GetStatus()[0].Status = %v, want Linked", status[0].Status)
+	}
+
+	// Unlink should also only touch the applicable target. (No-op for the missing one.)
+	if err := StoreRemove(root, "helix", entry); err != nil {
+		t.Fatalf("StoreRemove() error = %v", err)
+	}
+	assertMissing(t, linuxTarget)
+	assertMissing(t, windowsTarget)
+}
+
+func TestStorePerTargetWhenNoneApplicable(t *testing.T) {
+	root := t.TempDir()
+	createStore(t, root, "helix", map[string]string{"config.toml": "theme = \"base16\""})
+
+	target := filepath.Join(root, "windows", "helix")
+	entry := config.StoreEntry{Targets: []config.TargetEntry{
+		{Target: target, When: &config.WhenClause{OS: config.Strings{"windows"}}},
+	}}
+
+	withPlatform(t, platform.Info{OS: "linux"})
+
+	if err := Store(root, "helix", entry); err != nil {
+		t.Fatalf("Store() error = %v", err)
+	}
+	assertMissing(t, target)
+
+	// GetStatus on a store with zero applicable targets returns nothing,
+	// not a "no target configured" error.
+	status := GetStatus(root, "helix", entry)
+	if len(status) != 0 {
+		t.Fatalf("GetStatus() = %+v, want empty", status)
 	}
 }

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -118,7 +118,9 @@ func RenderDetail(root, name string, cfg *config.Config, pi platform.Info, d *De
 	}
 	b.WriteString("\n")
 
-	// File/target bodies.
+	// File/target bodies. GetStatus only reports applicable targets, so
+	// non-applicable ones get rendered as "skipped on this platform" rather
+	// than the misleading "0/0 missing" they'd show with empty status.
 	results := storeops.GetStatus(root, name, entry)
 	byTarget := groupByTarget(results)
 
@@ -127,6 +129,11 @@ func RenderDetail(root, name string, cfg *config.Config, pi platform.Info, d *De
 		// no-op
 	case len(targets) == 1:
 		t := targets[0]
+		if !targetApplies(t, pi) {
+			b.WriteString("  " + StyleDim.Render("skipped on this platform"))
+			b.WriteString("\n")
+			break
+		}
 		if t.HasFileMode() {
 			b.WriteString(renderFilesBlock(byTarget[t.Target]))
 		} else {
@@ -137,6 +144,11 @@ func RenderDetail(root, name string, cfg *config.Config, pi platform.Info, d *De
 	default:
 		for _, t := range targets {
 			expanded := d.IsExpanded(name, t.Target)
+			if !targetApplies(t, pi) {
+				b.WriteString(renderSkippedTargetRule(t.Target, width))
+				b.WriteString("\n")
+				continue
+			}
 			agg := aggregate(byTarget[t.Target])
 			b.WriteString(renderTargetRule(t.Target, agg, linkedCount(byTarget[t.Target]), totalCount(byTarget[t.Target]), expanded, width))
 			b.WriteString("\n")
@@ -152,6 +164,31 @@ func RenderDetail(root, name string, cfg *config.Config, pi platform.Info, d *De
 		}
 	}
 	return b.String()
+}
+
+// targetApplies reports whether a target's per-target when: clause matches
+// the current platform. Targets without a when: always apply.
+func targetApplies(t config.TargetEntry, pi platform.Info) bool {
+	return t.When == nil || t.When.Matches(pi)
+}
+
+// renderSkippedTargetRule mirrors renderTargetRule's layout for a target
+// that is excluded by its when: clause: same indent, same right-aligned
+// label slot, but everything muted and no expand arrow or count.
+func renderSkippedTargetRule(target string, width int) string {
+	title := "  " + StyleDim.Render(target)
+	right := lipgloss.NewStyle().Foreground(ColorDim).Render("skipped on this platform")
+	innerWidth := width - 2
+	if innerWidth < 20 {
+		innerWidth = 20
+	}
+	titleW := lipgloss.Width(title)
+	rightW := lipgloss.Width(right)
+	fill := innerWidth - titleW - rightW - 1
+	if fill < 1 {
+		fill = 1
+	}
+	return "  " + title + " " + strings.Repeat(" ", fill) + right
 }
 
 // line renders a two-column "label  value" row with aligned columns.

--- a/internal/tui/ops.go
+++ b/internal/tui/ops.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cushycush/store/v2/internal/doctor"
 	"github.com/cushycush/store/v2/internal/importer"
 	"github.com/cushycush/store/v2/internal/linker"
+	"github.com/cushycush/store/v2/internal/platform"
 	storeops "github.com/cushycush/store/v2/internal/store"
 )
 
@@ -440,10 +441,12 @@ func CmdTargetWhen(root string, cfg *config.Config, name, target, expr string) t
 			return OpResult{Label: "target when", Kind: ActivityErr, Msg: err.Error(), Err: err, Reload: true}
 		}
 		newTarget := entry.Targets[idx]
-		if when == nil {
+		if when == nil || when.Matches(platform.Detect()) {
 			if err := storeops.StoreTarget(root, name, newTarget); err != nil {
 				return OpResult{Label: "target when", Kind: ActivityErr, Msg: err.Error(), Err: err, Reload: true}
 			}
+		}
+		if when == nil {
 			return OpResult{Label: "target when", Kind: ActivityOK, Msg: "cleared when on " + name + " target " + target, Reload: true}
 		}
 		return OpResult{Label: "target when", Kind: ActivityOK, Msg: "set when on " + name + " target " + target, Reload: true}

--- a/internal/tui/ops.go
+++ b/internal/tui/ops.go
@@ -402,6 +402,125 @@ func CmdTargetModify(root string, cfg *config.Config, name, target string, files
 	}
 }
 
+// CmdTargetWhen sets or clears the per-target when: clause on a specific
+// target. An empty expression clears the clause. The expression syntax is
+// space-separated key=value pairs where the value may be a single string or
+// a comma-separated list, e.g. "os=linux,darwin shell=zsh". After updating
+// the config, the symlink is unlinked first and then re-linked only if the
+// new clause matches the current platform.
+func CmdTargetWhen(root string, cfg *config.Config, name, target, expr string) tea.Cmd {
+	return func() tea.Msg {
+		if name == "" || target == "" {
+			return OpResult{Label: "target when", Kind: ActivityWarn, Msg: "need both store name and target path"}
+		}
+		when, err := parseWhenExpression(expr)
+		if err != nil {
+			return OpResult{Label: "target when", Kind: ActivityErr, Msg: err.Error(), Err: err}
+		}
+		entry, ok := cfg.Stores[name]
+		if !ok {
+			return OpResult{Label: "target when", Kind: ActivityErr, Msg: "no such store: " + name}
+		}
+		entry.MigrateToMultiTarget()
+		idx := -1
+		for i, t := range entry.Targets {
+			if sameTargetPath(t.Target, target) {
+				idx = i
+				break
+			}
+		}
+		if idx < 0 {
+			return OpResult{Label: "target when", Kind: ActivityErr, Msg: "no such target: " + target}
+		}
+		oldTarget := entry.Targets[idx]
+		_ = storeops.StoreRemoveTarget(root, name, oldTarget)
+		entry.Targets[idx].When = when
+		cfg.Stores[name] = entry
+		if err := config.Save(root, cfg); err != nil {
+			return OpResult{Label: "target when", Kind: ActivityErr, Msg: err.Error(), Err: err, Reload: true}
+		}
+		newTarget := entry.Targets[idx]
+		if when == nil {
+			if err := storeops.StoreTarget(root, name, newTarget); err != nil {
+				return OpResult{Label: "target when", Kind: ActivityErr, Msg: err.Error(), Err: err, Reload: true}
+			}
+			return OpResult{Label: "target when", Kind: ActivityOK, Msg: "cleared when on " + name + " target " + target, Reload: true}
+		}
+		return OpResult{Label: "target when", Kind: ActivityOK, Msg: "set when on " + name + " target " + target, Reload: true}
+	}
+}
+
+// parseWhenExpression turns a space-separated key=value string into a
+// WhenClause. Empty or whitespace-only input returns (nil, nil) to mean
+// "clear the clause." Values may be comma-separated lists. The wsl key
+// takes a bool (true/false/1/0).
+func parseWhenExpression(s string) (*config.WhenClause, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, nil
+	}
+	out := &config.WhenClause{}
+	for _, field := range strings.Fields(s) {
+		eq := strings.IndexByte(field, '=')
+		if eq <= 0 || eq == len(field)-1 {
+			return nil, fmt.Errorf("expected key=value, got %q", field)
+		}
+		key := strings.ToLower(strings.TrimSpace(field[:eq]))
+		raw := strings.TrimSpace(field[eq+1:])
+		if key == "wsl" {
+			b, err := parseBool(raw)
+			if err != nil {
+				return nil, fmt.Errorf("wsl=%q: %w", raw, err)
+			}
+			out.WSL = &b
+			continue
+		}
+		values := splitWhenValues(raw)
+		if len(values) == 0 {
+			return nil, fmt.Errorf("%s=: empty value", key)
+		}
+		switch key {
+		case "os":
+			out.OS = values
+		case "arch":
+			out.Arch = values
+		case "distro":
+			out.Distro = values
+		case "distro_version":
+			out.DistroVersion = values
+		case "hostname":
+			out.Hostname = values
+		case "shell":
+			out.Shell = values
+		default:
+			return nil, fmt.Errorf("unknown when key %q (valid: os, arch, distro, distro_version, hostname, shell, wsl)", key)
+		}
+	}
+	return out, nil
+}
+
+func splitWhenValues(raw string) config.Strings {
+	parts := strings.Split(raw, ",")
+	out := make(config.Strings, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func parseBool(s string) (bool, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "true", "1", "yes":
+		return true, nil
+	case "false", "0", "no":
+		return false, nil
+	}
+	return false, fmt.Errorf("expected true/false")
+}
+
 // CmdApplyTarget reconciles one target of a store without touching the
 // others. Used by the in-TUI target submenu.
 func CmdApplyTarget(root, name string, te config.TargetEntry) tea.Cmd {

--- a/internal/tui/palette.go
+++ b/internal/tui/palette.go
@@ -52,6 +52,7 @@ const (
 	IntentTargetAdd
 	IntentTargetRemove
 	IntentTargetModify
+	IntentTargetWhen
 	IntentSecretSet
 	IntentSecretGet
 	IntentSecretRemove
@@ -100,6 +101,8 @@ func PaletteCommands() []PaletteCmd {
 			Build: func(s string) Intent { return Intent{Kind: IntentTargetRemove, Arg: s, Name: "target remove"} }},
 		{Name: "target modify", Summary: "replace files or patterns on a target", Prompt: "<name> <path>",
 			Build: func(s string) Intent { return Intent{Kind: IntentTargetModify, Arg: s, Name: "target modify"} }},
+		{Name: "target when", Summary: "set or clear a target's platform filter", Prompt: "<name> <path>",
+			Build: func(s string) Intent { return Intent{Kind: IntentTargetWhen, Arg: s, Name: "target when"} }},
 		{Name: "secret set", Summary: "create or update an encrypted secret", Prompt: "<name>",
 			Build: func(s string) Intent { return Intent{Kind: IntentSecretSet, Arg: s, Name: "secret set"} }},
 		{Name: "secret get", Summary: "print the value of one decrypted secret", Prompt: "<name>",

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -708,6 +708,21 @@ func (a *App) dispatchIntent(i Intent) tea.Cmd {
 		}
 		a.openInput("target_modify_files", name+"\x00"+target, "files for "+target, "space-separated list", "")
 		return nil
+	case IntentTargetWhen:
+		name, target := splitTargetArgs(i.Arg)
+		if name == "" {
+			a.openInput("target_when_name", "", "store name", "", "")
+			return nil
+		}
+		if target == "" {
+			a.openInput("target_when_target", name, "target path", "", "")
+			return nil
+		}
+		a.openInput("target_when_value", name+"\x00"+target,
+			"when clause for "+target,
+			"e.g. os=linux,darwin shell=zsh — leave blank to clear",
+			currentTargetWhen(a.cfg, name, target))
+		return nil
 	}
 	return nil
 }
@@ -748,6 +763,10 @@ func (a *App) openRemoveConfirm(name string) {
 	entry := a.cfg.Stores[name]
 	body := []string{"this will:"}
 	for _, t := range entry.ResolvedTargets() {
+		if t.When != nil && !t.When.Matches(a.plat) {
+			body = append(body, "  · "+t.Target+" (skipped on this platform)")
+			continue
+		}
 		body = append(body, "  · unlink "+t.Target)
 	}
 	body = append(body, "  · delete the config entry",
@@ -804,6 +823,21 @@ func (a *App) runInput(action, ctx, value string) tea.Cmd {
 	case "target_modify_target":
 		a.openInput("target_modify_files", value+"\x00"+ctx, "files for "+value, "space-separated list", "")
 		return nil
+	case "target_when_name":
+		a.openInput("target_when_target", value, "target path", "", "")
+		return nil
+	case "target_when_target":
+		a.openInput("target_when_value", ctx+"\x00"+value,
+			"when clause for "+value,
+			"e.g. os=linux,darwin shell=zsh — leave blank to clear",
+			currentTargetWhen(a.cfg, ctx, value))
+		return nil
+	case "target_when_value":
+		parts := strings.SplitN(ctx, "\x00", 2)
+		if len(parts) != 2 {
+			return nil
+		}
+		return CmdTargetWhen(a.root, a.cfg, parts[0], parts[1], value)
 	case "target_modify_files":
 		// ctx packs "name\x00target" so we don't need extra state.
 		parts := strings.SplitN(ctx, "\x00", 2)
@@ -903,6 +937,57 @@ func currentTarget(entry config.StoreEntry) string {
 		return ts[0].Target
 	}
 	return ""
+}
+
+// currentTargetWhen returns the existing per-target when: clause for the
+// named store and target, formatted in the same key=value syntax accepted
+// by parseWhenExpression. Returns "" if the store, target, or when: clause
+// doesn't exist; that empty default communicates "no filter set" without
+// pre-seeding the input.
+func currentTargetWhen(cfg *config.Config, name, target string) string {
+	if cfg == nil {
+		return ""
+	}
+	entry, ok := cfg.Stores[name]
+	if !ok {
+		return ""
+	}
+	for _, t := range entry.ResolvedTargets() {
+		if !sameTargetPath(t.Target, target) {
+			continue
+		}
+		return formatWhenExpression(t.When)
+	}
+	return ""
+}
+
+// formatWhenExpression renders a WhenClause back into the parser's syntax
+// so the input prefill matches what the user would have typed.
+func formatWhenExpression(w *config.WhenClause) string {
+	if w == nil {
+		return ""
+	}
+	var parts []string
+	add := func(key string, vals config.Strings) {
+		if len(vals) == 0 {
+			return
+		}
+		parts = append(parts, key+"="+strings.Join(vals, ","))
+	}
+	add("os", w.OS)
+	add("arch", w.Arch)
+	add("distro", w.Distro)
+	add("distro_version", w.DistroVersion)
+	add("hostname", w.Hostname)
+	add("shell", w.Shell)
+	if w.WSL != nil {
+		if *w.WSL {
+			parts = append(parts, "wsl=true")
+		} else {
+			parts = append(parts, "wsl=false")
+		}
+	}
+	return strings.Join(parts, " ")
 }
 
 // renderMain composes the whole main view.

--- a/internal/tui/when_input_test.go
+++ b/internal/tui/when_input_test.go
@@ -1,0 +1,97 @@
+package tui
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/cushycush/store/v2/internal/config"
+)
+
+func TestParseWhenExpression(t *testing.T) {
+	tr := true
+	fa := false
+	tests := []struct {
+		name    string
+		in      string
+		want    *config.WhenClause
+		wantErr string
+	}{
+		{name: "empty clears", in: "", want: nil},
+		{name: "whitespace clears", in: "   ", want: nil},
+		{name: "single os", in: "os=linux", want: &config.WhenClause{OS: config.Strings{"linux"}}},
+		{name: "comma list", in: "os=linux,darwin", want: &config.WhenClause{OS: config.Strings{"linux", "darwin"}}},
+		{
+			name: "two fields",
+			in:   "os=linux shell=zsh",
+			want: &config.WhenClause{OS: config.Strings{"linux"}, Shell: config.Strings{"zsh"}},
+		},
+		{name: "wsl true", in: "wsl=true", want: &config.WhenClause{WSL: &tr}},
+		{name: "wsl false via 0", in: "wsl=0", want: &config.WhenClause{WSL: &fa}},
+		{name: "all known keys", in: "os=linux arch=amd64 distro=arch distro_version=rolling hostname=box shell=zsh wsl=false",
+			want: &config.WhenClause{
+				OS:            config.Strings{"linux"},
+				Arch:          config.Strings{"amd64"},
+				Distro:        config.Strings{"arch"},
+				DistroVersion: config.Strings{"rolling"},
+				Hostname:      config.Strings{"box"},
+				Shell:         config.Strings{"zsh"},
+				WSL:           &fa,
+			}},
+		{name: "missing equals", in: "linux", wantErr: "expected key=value"},
+		{name: "empty value", in: "os=", wantErr: "expected key=value"},
+		{name: "unknown key", in: "platform=linux", wantErr: "unknown when key"},
+		{name: "bad wsl", in: "wsl=maybe", wantErr: "wsl="},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseWhenExpression(tt.in)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error = %q, want substring %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("parseWhenExpression(%q) = %+v, want %+v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatWhenExpressionRoundTrip(t *testing.T) {
+	tr := true
+	cases := []*config.WhenClause{
+		nil,
+		{OS: config.Strings{"linux"}},
+		{OS: config.Strings{"linux", "darwin"}, Shell: config.Strings{"zsh"}},
+		{Hostname: config.Strings{"work-laptop"}, WSL: &tr},
+	}
+	for _, want := range cases {
+		s := formatWhenExpression(want)
+		got, err := parseWhenExpression(s)
+		if err != nil {
+			t.Fatalf("round trip parse(%q) error = %v", s, err)
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("round trip: got %+v from %q, want %+v", got, s, want)
+		}
+	}
+}
+
+func contains(haystack, needle string) bool {
+	if needle == "" {
+		return true
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What this does

A `when:` clause can now sit inside a `targets[]` entry, scoped to that one target rather than the whole store. The motivating case is one repo directory that wants to land at different paths per platform: helix lives at `~/.config/helix` on Linux and `~/AppData/Roaming/helix` on Windows. Before this you had to either keep two stores in sync or accept a stale symlink pointing at `~/AppData/...` on Linux. Now you write one store with two targets, each filtered to the platform that applies.

```yaml
stores:
  helix:
    targets:
      - target: "~/.config/helix"
        when:
          os: linux
      - target: "~/AppData/Roaming/helix"
        when:
          os: windows
```

Closes #61.

## How it works

Schema-side, `TargetEntry` grows a `When *WhenClause` field. A new `StoreEntry.ApplicableTargets(info)` method returns the resolved targets that match the current platform, and every mutation path (link, unlink, status, conflict checks) consults it. Per-target and store-level filters compose: the store-level one runs first via the existing `filterStoresByPlatform`, and if it rules a store out, none of its targets run.

`MigrateToSingleTarget` refuses to collapse back to single-target form when the remaining target carries a `when:`, since the single-target schema has no slot for it. Without this guard the TUI's "remove target" flow would silently drop the constraint.

`store doctor` learns two things. It stops flagging conflicts between two stores that claim the same path on disjoint platforms, since they never run together. And it reports per-target platform skips the same way it already reported store-level ones, so on a Linux box the windows-only target of a multi-target store shows up as an `info` issue rather than a missing symlink.

## TUI changes

The detail view now renders a non-applicable target as `skipped on this platform` next to its path, in place of the misleading `0/0 missing` it would have shown before. The remove-confirm overlay tags skipped targets the same way so the body matches what the unlink will actually do.

A new `target when` palette command sets or clears a target's filter from inside the TUI. Pick the store and target, then type a `key=value` expression like `os=linux,darwin shell=zsh`. Submitting empty clears the clause. The store unlinks before the edit and re-links after, but only when the new clause matches the current platform (or is nil). Setting `when=windows` on Linux leaves the store unlinked; clearing or setting `when=linux` on Linux re-links it.

## Tests

The config matrix covers ApplicableTargets across Linux, Windows, and Darwin, plus the single-target fast path and the migrate-keeps-multi case. Round-trip parse/save covers per-target `when:` end-to-end. Two integration tests in the store package verify that link, status, and unlink only touch the applicable target, using a `detectPlatform` seam to fake the platform deterministically. Doctor tests cover the per-target skip message and the no-false-positive conflict case. The TUI parser ships with 14 cases and a parse/format round-trip test.

## Caveats

Branch picked up the freshly-merged 2.5.1 fix from main during ship, so the diff includes that merge commit. The CHANGELOG resolved the version ordering: 2.6.0 sits above 2.5.1.

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...` clean
- [x] Manual: build a fixture with helix-shaped multi-target `when:` and verify only the linux target gets linked on Linux
- [x] Pre-landing self-review caught and fixed a bug where `target when` left the store unlinked when the new clause matched the platform