### PR TITLE
fix: surface MS Store CLI shadowing on Windows (#60)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,22 @@ $ mv store /usr/local/bin/
 
 > Windows: creating symlinks requires either Developer Mode enabled in Settings → Privacy & Security → For developers, or running your terminal as Administrator. `store doctor` detects the missing capability and warns on first run. Alternatively, run `store` from WSL.
 
+### Windows: PowerShell wrapper for the `store` command
+
+Windows ships with a Microsoft Store CLI shim at `%LocalAppData%\Microsoft\WindowsApps\store.exe`. Because that path comes ahead of `~\go\bin` on `PATH`, typing `store` resolves to the Microsoft shim rather than this tool, even after `go install`. You can confirm with `where.exe store` (the shim path lists first).
+
+The fix is a one-liner in your PowerShell `$PROFILE`:
+
+```powershell
+function store {
+  & "$HOME\go\bin\store.exe" @args
+}
+```
+
+Reload the profile (`. $PROFILE`) and `store` resolves to this tool from then on. The function takes precedence over PATH lookup in PowerShell so the shim never wins.
+
+When the binary detects it is being shadowed (you ran `~\go\bin\store.exe` directly while `where.exe store` reports the shim ahead of it), it prints the same hint to stderr once. After the first time it remembers (via a marker in `%AppData%\store\windows-shim-hint-shown`) and stays quiet. Delete the marker if you want to see the hint again. Reported in #60.
+
 ---
 
 ## Quick Start

--- a/cmd/store/collision.go
+++ b/cmd/store/collision.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// checkWindowsShimCollision prints a one-time hint when this binary is being
+// shadowed on PATH by the Microsoft Store CLI stub. The stub lives at
+// %LocalAppData%\Microsoft\WindowsApps\store.exe and is auto-prepended to
+// PATH, so typing `store` resolves to the stub instead of this binary even
+// after `go install`. The hint points the user at the PowerShell wrapper
+// documented in the README.
+//
+// The hint prints once per machine; a marker file under the user's config
+// directory suppresses it on subsequent runs. Delete the marker to see it
+// again. No-op on non-Windows.
+func checkWindowsShimCollision() {
+	if runtime.GOOS != "windows" {
+		return
+	}
+	marker, err := collisionMarkerPath()
+	if err != nil {
+		return
+	}
+	if _, err := os.Stat(marker); err == nil {
+		return
+	}
+	out, err := exec.Command("where.exe", "store").Output()
+	if err != nil {
+		return
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return
+	}
+	if !shimShadowsBinary(string(out), exe) {
+		return
+	}
+
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "  note: `store` on your PATH resolves to the Microsoft Store CLI shim,")
+	fmt.Fprintln(os.Stderr, "  not this binary. To make `store` always invoke this tool, add to your")
+	fmt.Fprintln(os.Stderr, "  PowerShell $PROFILE:")
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, `    function store { & "$HOME\go\bin\store.exe" @args }`)
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "  Showing this once. See README install section for details.")
+	fmt.Fprintln(os.Stderr)
+
+	_ = os.MkdirAll(filepath.Dir(marker), 0o755)
+	_ = os.WriteFile(marker, []byte("shown\n"), 0o644)
+}
+
+// shimShadowsBinary parses `where.exe store` output and returns true when
+// the first PATH match is a WindowsApps stub that is not this binary. The
+// parser is split out from the orchestration so it stays testable on every
+// platform.
+func shimShadowsBinary(whereOut, exePath string) bool {
+	for _, line := range strings.Split(whereOut, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if strings.EqualFold(line, exePath) {
+			return false
+		}
+		return strings.Contains(strings.ToLower(line), `\windowsapps\`)
+	}
+	return false
+}
+
+func collisionMarkerPath() (string, error) {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "store", "windows-shim-hint-shown"), nil
+}

--- a/cmd/store/collision_test.go
+++ b/cmd/store/collision_test.go
@@ -1,0 +1,77 @@
+package main
+
+import "testing"
+
+func TestShimShadowsBinary(t *testing.T) {
+	const ourBin = `C:\Users\cush\go\bin\store.exe`
+	const shim = `C:\Users\cush\AppData\Local\Microsoft\WindowsApps\store.exe`
+
+	tests := []struct {
+		name      string
+		whereOut  string
+		exe       string
+		want      bool
+	}{
+		{
+			name:     "shim listed first, our binary second",
+			whereOut: shim + "\n" + ourBin + "\n",
+			exe:      ourBin,
+			want:     true,
+		},
+		{
+			name:     "our binary listed first",
+			whereOut: ourBin + "\n" + shim + "\n",
+			exe:      ourBin,
+			want:     false,
+		},
+		{
+			name:     "only our binary on PATH",
+			whereOut: ourBin + "\n",
+			exe:      ourBin,
+			want:     false,
+		},
+		{
+			name:     "only the shim on PATH",
+			whereOut: shim + "\n",
+			exe:      ourBin,
+			want:     true,
+		},
+		{
+			name:     "no matches",
+			whereOut: "",
+			exe:      ourBin,
+			want:     false,
+		},
+		{
+			name:     "case-insensitive match on exe path",
+			whereOut: `c:\users\cush\go\bin\store.exe` + "\n",
+			exe:      ourBin,
+			want:     false,
+		},
+		{
+			name:     "case-insensitive match on WindowsApps segment",
+			whereOut: `C:\Users\cush\AppData\Local\Microsoft\WINDOWSAPPS\store.exe` + "\n",
+			exe:      ourBin,
+			want:     true,
+		},
+		{
+			name:     "third-party store.exe somewhere else does not trigger hint",
+			whereOut: `C:\tools\store.exe` + "\n" + ourBin + "\n",
+			exe:      ourBin,
+			want:     false,
+		},
+		{
+			name:     "leading blank lines are skipped",
+			whereOut: "\n\n" + shim + "\n",
+			exe:      ourBin,
+			want:     true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shimShadowsBinary(tt.whereOut, tt.exe); got != tt.want {
+				t.Fatalf("shimShadowsBinary() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/store/main.go
+++ b/cmd/store/main.go
@@ -9,6 +9,7 @@ var (
 )
 
 func main() {
+	checkWindowsShimCollision()
 	// Git-style: hand off to an external `store-<cmd>` (or a known
 	// companion binary like `stock`) before cobra sees the args.
 	if len(os.Args) >= 2 {


### PR DESCRIPTION
## What this does

On Windows, `%LocalAppData%\Microsoft\WindowsApps\store.exe` (the Microsoft Store CLI shim) sits ahead of `~\go\bin` on PATH and wins command resolution. After `go install`, typing `store apply` runs the Microsoft shim instead of this tool, and the user gets no signal that anything is wrong. @OliStarCooke reported this in #60 and shared a PowerShell `$PROFILE` wrapper that bypasses PATH lookup. This PR makes that fix discoverable.

I considered renaming the binary, shipping a Windows-only `dotstore` alias, publishing to Scoop, and a few other options. The reporter himself said "more of a heads up kind of thing," and a Scoop or rename is a much heavier intervention for what is, today, a small Windows user base. So this PR keeps the binary name and adds two guidance layers.

## How it works

**Layer 1: README.** A new Installation subsection documents the collision, shows `where.exe store` so the reader can confirm the shim is winning, and gives the PowerShell `$PROFILE` snippet:

```powershell
function store {
  & "$HOME\go\bin\store.exe" @args
}
```

It also explains why the function is enough (PowerShell function dispatch beats PATH lookup, so the shim never wins for typed `store` invocations).

**Layer 2: runtime hint.** `checkWindowsShimCollision` runs at the top of `main()`. On Windows only, it shells out to `where.exe store`, parses the result, and if the first match is a `WindowsApps` path that is not this binary, prints the same hint to stderr. A marker file at `%AppData%\store\windows-shim-hint-shown` suppresses subsequent prints; deleting it brings the hint back. No-op on Linux and macOS, gated entirely by `runtime.GOOS == "windows"` so the cost on other platforms is one branch.

The case where this layer actually helps is when a user invokes the binary by full path (`~\go\bin\store.exe apply`) after the shim has confused them — they get the wrapper snippet right where they're working.

## Tests

`shimShadowsBinary` is the pure parser, split out so it stays testable on every platform. Nine cases cover shim-first, our-binary-first, only-shim, only-our-binary, empty input, case-insensitive matching on both the exe path and the WindowsApps segment, third-party `store.exe` outside WindowsApps (does not trigger), and leading blank lines. The orchestration around it (filesystem marker, `where.exe`, `os.Executable`) only runs on Windows so I haven't covered those paths from a Linux runner; the marker logic is small and the rest is stdlib.

## Caveats

- The runtime hint only fires when the real binary actually executes. If the user types `store apply` and PATH resolves to the shim, the shim runs and our code never sees the invocation. The README is the catch for that case.
- The marker file is per-user, not per-shell. If the user has multiple Windows accounts they would each see the hint once.
- I did not add a `store doctor` check for the same condition, since the reporter's own assessment was that this is a heads-up rather than a recurring health concern. Easy to add later if the issue resurfaces.

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...` clean on Linux
- [x] Unit tests pass for the parser across the nine cases listed above
- [ ] Manual verification on a Windows machine with the shim present (I do not have one; @OliStarCooke or anyone on Windows can confirm the hint fires once and stays quiet thereafter)